### PR TITLE
feat: SliceReducer trait for isolated state slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ data-race-free parallel reducers at compile time.
 
 ```
 Store<S, R>            Generic state container
-Reducer<S>             Trait with associated Event type
-  ├── SliceReducer     Operates on a single state slice (planned)
-  └── RootReducer      Combines slice reducers (planned)
+Reducer<S>             Trait with associated Event type — operates on full state
+SliceReducer           Trait with associated Slice + Event — operates on a state slice
+HasSlice<T>            Bridges a slice to the global state (user-implemented)
+ReducerOutput<S, E>    Return type: new state + optional side events
+RootReducer            Combines slice reducers (planned)
 Middleware             Pre/post dispatch hooks (planned)
 ParallelRootReducer    Rayon-based parallel execution (planned)
 ```
@@ -26,7 +28,22 @@ ParallelRootReducer    Rayon-based parallel execution (planned)
 ```rust
 pub trait Reducer<S> {
     type Event;
-    fn reduce(&self, state: &S, event: Self::Event) -> S;
+    fn reduce(&self, state: &S, event: &Self::Event) -> ReducerOutput<S, Self::Event>;
+}
+
+pub trait SliceReducer {
+    type Event;
+    type Slice;
+    fn reduce(
+        &self,
+        slice: &Self::Slice,
+        event: &Self::Event,
+    ) -> ReducerOutput<Self::Slice, Self::Event>;
+}
+
+pub trait HasSlice<T> {
+    fn slice(&self) -> &T;
+    fn set_slice(self, slice: T) -> Self;
 }
 
 pub struct Store<S, R> { /* ... */ }
@@ -49,8 +66,8 @@ by external signals (sensor readings, price updates, timer ticks), not user inte
 | Phase   | Feature                            | Status  |
 |---------|------------------------------------|---------|
 | 1 — MVP | [Store, Event, Reducer][i2]        | done    |
-| 1       | [ReducerOutput][i3]                | planned |
-| 1       | [SliceReducer][i4]                 | planned |
+| 1       | [ReducerOutput][i3]                | done    |
+| 1       | [SliceReducer][i4]                 | done    |
 | 1       | [Sequential RootReducer][i5]       | planned |
 | 1       | [Middleware][i6]                    | planned |
 | 1       | [Documentation & EMS example][i7]  | planned |

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,55 @@
+# Architecture
+
+## Reducer traits
+
+Ruxe exposes two reducer traits with different scopes:
+
+- `Reducer<S>` — operates on the full state tree
+- `SliceReducer` — operates on an isolated slice of the state
+
+Both produce a `ReducerOutput` containing the new state and optional side events
+to re-dispatch.
+
+`HasSlice<T>` bridges the global state to a slice: the user implements it on their
+state struct to expose each slice for reading (`slice`) and replacement
+(`set_slice`).
+
+```mermaid
+classDiagram
+    class Reducer~S~ {
+        <<trait>>
+        +Event
+        +reduce(state: &S, event: &Event) ReducerOutput~S, Event~
+    }
+
+    class SliceReducer {
+        <<trait>>
+        +Event
+        +Slice
+        +reduce(slice: &Slice, event: &Event) ReducerOutput~Slice, Event~
+    }
+
+    class HasSlice~T~ {
+        <<trait>>
+        +slice() &T
+        +set_slice(slice: T) Self
+    }
+
+    class ReducerOutput~S, E~ {
+        +state: S
+        +side_events: Option~Vec~E~~
+    }
+
+    Reducer ..> ReducerOutput : returns
+    SliceReducer ..> ReducerOutput : returns
+    HasSlice ..> SliceReducer : bridges global state to slice
+```
+
+## Isolation by construction
+
+Slice reducers cannot access other slices. The `SliceReducer::reduce` method
+only receives `&Self::Slice` — no other slice is in scope, so access is
+structurally impossible rather than checked at runtime.
+
+This property is what makes slice reducers candidates for parallel execution
+(planned).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 mod reducer;
+mod state;
 mod store;
 
 pub use reducer::Reducer;
 pub use reducer::ReducerOutput;
+pub use reducer::SliceReducer;
+pub use state::HasSlice;
 pub use store::DispatchError;
 pub use store::Store;

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -10,11 +10,177 @@ pub struct ReducerOutput<S, E> {
 /// containing the new state and optionally side events to re-dispatch.
 ///
 /// The reducer does not modify the state in place — it produces a new value
-/// that the [`Store`] will use to replace the current state.
+/// that the [`crate::Store`] will use to replace the current state.
 pub trait Reducer<S> {
     /// The event type this reducer handles.
     type Event;
 
     /// Computes a new state and optional side events from the current state and an event.
-    fn reduce(&self, state: &S, event: Self::Event) -> ReducerOutput<S, Self::Event>;
+    fn reduce(&self, state: &S, event: &Self::Event) -> ReducerOutput<S, Self::Event>;
+}
+
+/// A reducer takes a slice of the current state and an event, and returns a [`ReducerOutput`]
+/// containing the new state slice and optionally side events to re-dispatch.
+///
+/// The reducer does not modify the state slice in place — it produces a new value
+/// that the [`crate::Store`] will use to replace the current state slice.
+///
+/// Slice reducers are structurally isolated: the `reduce` method only receives
+/// `&Self::Slice`, making access to other slices impossible by construction.
+pub trait SliceReducer {
+    /// The event type this reducer handles.
+    type Event;
+    /// The slice of global state this reducer operates on.
+    type Slice;
+
+    /// Computes a new state slice and optional side events from the current state and an event.
+    fn reduce(
+        &self,
+        slice: &Self::Slice,
+        event: &Self::Event,
+    ) -> ReducerOutput<Self::Slice, Self::Event>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::reducer::tests::Event::{FirstValueUpdate, SecondValueUpdate};
+    use crate::{HasSlice, ReducerOutput, SliceReducer};
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct FirstSlice {
+        value: u32,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct SecondSlice {
+        value: f64,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ExampleState {
+        first_slice: FirstSlice,
+        second_slice: SecondSlice,
+    }
+
+    impl HasSlice<FirstSlice> for ExampleState {
+        fn slice(&self) -> &FirstSlice {
+            &self.first_slice
+        }
+
+        fn set_slice(mut self, slice: FirstSlice) -> Self {
+            self.first_slice = slice;
+            self
+        }
+    }
+
+    impl HasSlice<SecondSlice> for ExampleState {
+        fn slice(&self) -> &SecondSlice {
+            &self.second_slice
+        }
+
+        fn set_slice(mut self, slice: SecondSlice) -> Self {
+            self.second_slice = slice;
+            self
+        }
+    }
+
+    enum Event {
+        FirstValueUpdate { value: u32 },
+        SecondValueUpdate { value: f64 },
+    }
+
+    struct FirstSliceReducer {}
+
+    impl SliceReducer for FirstSliceReducer {
+        type Event = Event;
+        type Slice = FirstSlice;
+
+        fn reduce(
+            &self,
+            slice: &Self::Slice,
+            event: &Self::Event,
+        ) -> ReducerOutput<Self::Slice, Self::Event> {
+            match event {
+                FirstValueUpdate { value } => ReducerOutput {
+                    state: FirstSlice { value: *value },
+                    side_events: None,
+                },
+                _ => ReducerOutput {
+                    state: slice.clone(),
+                    side_events: None,
+                },
+            }
+        }
+    }
+
+    struct SecondSliceReducer {}
+
+    impl SliceReducer for SecondSliceReducer {
+        type Event = Event;
+        type Slice = SecondSlice;
+
+        fn reduce(
+            &self,
+            slice: &Self::Slice,
+            event: &Self::Event,
+        ) -> ReducerOutput<Self::Slice, Self::Event> {
+            match event {
+                SecondValueUpdate { value } => ReducerOutput {
+                    state: SecondSlice { value: *value },
+                    side_events: None,
+                },
+                _ => ReducerOutput {
+                    state: slice.clone(),
+                    side_events: None,
+                },
+            }
+        }
+    }
+
+    fn dispatch_event(event: Event, example_state: ExampleState) -> ExampleState {
+        let new_state = example_state.clone();
+        let first_slice_reducer = FirstSliceReducer {};
+        let second_slice_reducer = SecondSliceReducer {};
+
+        let first_slice_update = first_slice_reducer.reduce(example_state.slice(), &event);
+        let new_state = new_state.set_slice(first_slice_update.state);
+        let second_slice_update = second_slice_reducer.reduce(example_state.slice(), &event);
+        let new_state = new_state.set_slice(second_slice_update.state);
+        new_state
+    }
+
+    fn make_state() -> ExampleState {
+        ExampleState {
+            first_slice: FirstSlice { value: 1 },
+            second_slice: SecondSlice { value: 1.5 },
+        }
+    }
+
+    #[test]
+    fn first_slice_reducer() {
+        let state = make_state();
+
+        let new_state = dispatch_event(FirstValueUpdate { value: 2 }, state.clone());
+        assert_eq!(
+            new_state,
+            ExampleState {
+                first_slice: FirstSlice { value: 2 },
+                ..state
+            }
+        );
+    }
+
+    #[test]
+    fn second_slice_reducer() {
+        let state = make_state();
+
+        let new_state = dispatch_event(SecondValueUpdate { value: 1.7 }, state.clone());
+        assert_eq!(
+            new_state,
+            ExampleState {
+                second_slice: SecondSlice { value: 1.7 },
+                ..state
+            }
+        );
+    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,7 @@
+/// Gives access to a state slice for reading and update.
+pub trait HasSlice<T> {
+    /// Returns a reference to the slice.
+    fn slice(&self) -> &T;
+    /// Replaces the slice with a new value, returning the updated state.
+    fn set_slice(self, slice: T) -> Self;
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -45,7 +45,7 @@ impl<S, R: Reducer<S, Event = E>, E> Store<S, R, E> {
     /// in FIFO order. Returns an error if the re-dispatch depth exceeds
     /// `max_depth`.
     pub fn dispatch(&mut self, event: R::Event) -> Result<(), DispatchError> {
-        let output = self.reducer.reduce(&self.state, event);
+        let output = self.reducer.reduce(&self.state, &event);
         self.apply_output(output, 0)?;
 
         while let Some(pending) = self.queue.pop_front() {
@@ -88,7 +88,7 @@ impl<S, R: Reducer<S, Event = E>, E> Store<S, R, E> {
         pending_event: PendingEvent<R::Event>,
     ) -> Result<(), DispatchError> {
         let event = pending_event.event;
-        let output = self.reducer.reduce(&self.state, event);
+        let output = self.reducer.reduce(&self.state, &event);
         self.apply_output(output, pending_event.depth)
     }
 }
@@ -125,19 +125,19 @@ mod tests {
         fn reduce(
             &self,
             state: &SimpleState,
-            event: Self::Event,
+            event: &Self::Event,
         ) -> ReducerOutput<SimpleState, Event> {
             match event {
                 FirstValueUpdate { value } => ReducerOutput {
                     state: SimpleState {
-                        first_value: value,
+                        first_value: *value,
                         ..*state
                     },
                     side_events: None,
                 },
                 SecondValueUpdate { value } => ReducerOutput {
                     state: SimpleState {
-                        second_value: value,
+                        second_value: *value,
                         ..*state
                     },
                     side_events: None,


### PR DESCRIPTION
## Summary

Introduces `SliceReducer`, a reducer trait that operates on an isolated slice of the
global state. Slices are bridged to the global state via a new `HasSlice<T>` trait,
which the user implements on their own state struct.

Isolation is enforced by construction: `SliceReducer::reduce` only receives
`&Self::Slice`, making access to other slices structurally impossible — not a runtime
check.

## Related Issue

Closes #4

## Changes

- `SliceReducer` trait (standalone, not a subtrait of `Reducer`) with associated
  `Slice` and `Event` types
- `HasSlice<T>` trait in `src/state.rs` — owned `set_slice` pattern (consumes and
  reconstructs) to keep the door open for future parallel execution
- `Reducer::reduce` signature updated: `event: Self::Event` → `event: &Self::Event`,
  so the same event can be passed to multiple reducers without cloning
- Tests: two slice reducers on two slices of the same state, verifying each only
  mutates its own slice
- `docs/dev/architecture.md` with Mermaid classDiagram of the trait relationships
- README updated (Design, Core API, Roadmap — `ReducerOutput` and `SliceReducer`
  now marked `done`)

## Notes for Reviewers

- The supertrait option (`SliceReducer: Reducer<Self::Slice>`) was considered and
  rejected: it would have required two separate `impl` blocks per reducer without
  adding value. Standalone trait keeps a single `impl` site.
- `RootReducer` composition (looping over heterogeneous slice reducers) is out of
  scope — that's issue #5.