### PR TITLE
feat: Middleware trait with pre/post dispatch hooks

### DIFF
--- a/.claude/rules/rust-quality.md
+++ b/.claude/rules/rust-quality.md
@@ -83,6 +83,52 @@ pub fn dispatch(&mut self, event: Event) -> Result<&State, DispatchError> {
 
 Use the type system to prevent invalid states at compile time.
 
+## Closure captures and mutability
+
+`move` closures take ownership of their captures, but **mutability of the source
+binding is preserved** — it doesn't get auto-promoted. If the closure body calls a
+captured `FnMut` or mutates a captured value, the source binding must be declared
+`mut`.
+
+```rust
+// BAD - compile error: cannot borrow `self.callback` as mutable
+fn wrap(
+    self: Box<Self>,
+    next: Box<dyn FnMut(&S, E) -> R>,
+) -> Box<dyn FnMut(&S, E) -> R> {
+    Box::new(move |state, event| {
+        (self.callback)(state);   // needs &mut self.callback
+        next(state, event)         // needs &mut next
+    })
+}
+
+// GOOD - `mut` on bindings enables mutable capture
+fn wrap(
+    mut self: Box<Self>,
+    mut next: Box<dyn FnMut(&S, E) -> R>,
+) -> Box<dyn FnMut(&S, E) -> R> {
+    Box::new(move |state, event| {
+        (self.callback)(state);
+        next(state, event)
+    })
+}
+```
+
+The `mut` on a function parameter is a **binding modifier**, not part of the
+signature contract — invisible to callers. Keep it when the closure body needs
+mutable access to a captured `FnMut`/`FnOnce` or mutates a captured field.
+
+Rule of thumb:
+
+| Capture kind | Called from move closure | `mut` on source binding? |
+| ------------ | ------------------------ | ------------------------ |
+| `Fn`         | Yes                      | No                       |
+| `FnMut`      | Yes                      | **Yes**                  |
+| `FnOnce`     | Yes (once)               | No (binding is consumed) |
+
+When reviewing a move closure, ask: *"does the body call a captured `FnMut`, or
+write to a captured field?"* If yes, every relevant source binding needs `mut`.
+
 ## Prefer generics over trait objects
 
 Use static dispatch (generics) by default. Only use dynamic dispatch (`dyn Trait`) when
@@ -131,3 +177,29 @@ Follow Rust naming conventions:
 | Modules     | `snake_case`  | `root_reducer`       |
 | Traits      | `PascalCase`  | `SliceReducer`       |
 | Type params | `PascalCase`  | `S`, `State`, `E`    |
+
+## Code review — diagnose before prescribing
+
+When reviewing code, identify the **smallest fix** that addresses the actual problem
+before proposing structural changes.
+
+A symptom (verbose paths, repeated boilerplate, awkward call sites) often has multiple
+possible fixes ordered by cost:
+
+1. **Local syntactic fix** — `use` import, type alias, `cargo fmt`
+2. **In-place rename** — better identifier, no structure change
+3. **Local refactor** — extract helper, group related items
+4. **Structural refactor** — split modules, change visibility, reorganize file layout
+
+Start at the top of the list and stop at the first fix that resolves the symptom.
+Proposing a structural refactor when a `use` statement suffices is **noise** — it
+overrides the author's design choices for no real benefit.
+
+Concrete example: long fully-qualified paths inside a nested module (e.g.
+`crate::store::tests::fixtures::SimpleState` everywhere) is a **`use` problem**, not
+a structural problem. The fix is `use super::super::fixtures::*;`, not flattening
+the module hierarchy.
+
+When in doubt, ask the author: *"is the encapsulation intentional, or just an
+artifact of the path verbosity?"* — the answer dictates whether to fix locally
+or restructure.

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,0 +1,89 @@
+//! Demonstrates wrapping a Store with a custom logging middleware.
+//!
+//! Run with: `cargo run --example middleware`
+//!
+//! Expected output:
+//! ```text
+//! initial state: State(0)
+//! dispatching increment
+//! next state State(1)
+//! dispatching decrement
+//! next state State(0)
+//! ```
+
+use ruxe::{Middleware, Next, Reducer, ReducerOutput, Store};
+use std::fmt;
+use std::fmt::Display;
+
+enum Event {
+    Increment {},
+    Decrement {},
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Event::Increment {} => f.write_str("increment"),
+            Event::Decrement {} => f.write_str("decrement"),
+        }
+    }
+}
+
+struct State {
+    value: i32,
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "State({})", self.value)
+    }
+}
+
+struct CounterReducer;
+
+impl Reducer<State> for CounterReducer {
+    type Event = Event;
+
+    fn reduce(&self, state: &State, event: &Event) -> ReducerOutput<State, Event> {
+        match event {
+            Event::Increment {} => ReducerOutput {
+                state: State {
+                    value: state.value + 1,
+                },
+                side_events: None,
+            },
+            Event::Decrement {} => ReducerOutput {
+                state: State {
+                    value: state.value - 1,
+                },
+                side_events: None,
+            },
+        }
+    }
+}
+
+struct LoggingMiddleware;
+
+impl Middleware<State, Event> for LoggingMiddleware {
+    fn wrap(self: Box<Self>, mut next: Next<State, Event>) -> Next<State, Event> {
+        Box::new(move |state, event| {
+            println!("dispatching {event}");
+            let output = next(state, event);
+            println!("next state {state}");
+            output
+        })
+    }
+}
+fn main() {
+    let state = State { value: 0 };
+    println!("initial state: {state}");
+    let mut store = Store::new(state, CounterReducer, vec![Box::new(LoggingMiddleware)], 5);
+
+    store
+        .dispatch(Event::Increment {})
+        .expect("Failed to increment value");
+
+    store
+        .dispatch(Event::Decrement {})
+        .expect("Failed to decrement value");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,17 @@
+//! Redux-inspired state management for Rust.
+//!
+//! A [`Store`] dispatches events through a [`Middleware`] chain to a
+//! [`Reducer`], which produces a new state. Reducers can target the full
+//! state or an isolated slice via [`SliceReducer`] (composed with tuple
+//! syntax). Side events emitted anywhere are re-dispatched in FIFO order.
+
+mod middleware;
 mod reducer;
 mod state;
 mod store;
 
+pub use middleware::Middleware;
+pub use middleware::Next;
 pub use reducer::Reducer;
 pub use reducer::ReducerOutput;
 pub use reducer::SliceReducer;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,45 @@
+//! Middleware chain composition for the dispatch pipeline.
+//!
+//! Middlewares wrap the dispatch chain to add cross-cutting concerns
+//! (logging, metrics, validation, conditional dispatch). They follow the
+//! onion model: the first middleware in the list is the outermost — it
+//! sees the event first and the resulting state last.
+//!
+//! ```text
+//! dispatch(event)
+//!     │
+//!     ▼
+//!  ┌─ M1 ───────────────────────────────┐
+//!  │ pre1                               │
+//!  │  ┌─ M2 ───────────────────────────┐│
+//!  │  │ pre2                           ││
+//!  │  │  ┌─ reducer ─────────────────┐ ││
+//!  │  │  │ state mutated in place    │ ││  ← commit
+//!  │  │  └───────────────────────────┘ ││
+//!  │  │ post2  (sees new state)        ││
+//!  │  └────────────────────────────────┘│
+//!  │ post1  (sees new state)            │
+//!  └────────────────────────────────────┘
+//! ```
+
+/// A node in the dispatch chain.
+///
+/// Mutates state in place and returns any side events. Code running after
+/// `next` returns observes the updated state.
+pub type Next<S, E> = Box<dyn FnMut(&mut S, E) -> Option<Vec<E>>>;
+
+/// A wrapper around the dispatch chain.
+///
+/// [`wrap`](Middleware::wrap) returns a closure that calls `next` zero or
+/// one time:
+///
+/// - **Calling `next`** runs the inner chain.
+/// - **Skipping `next`** short-circuits: state unchanged, side events come
+///   only from this middleware.
+///
+/// Registered with [`crate::Store::new`].
+pub trait Middleware<S, E> {
+    /// Composes with the inner chain `next`. The boxed `self` lets owned
+    /// state move into the returned closure.
+    fn wrap(self: Box<Self>, next: Next<S, E>) -> Next<S, E>;
+}

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -1,3 +1,8 @@
+//! Reducer traits: pure transformations from `(state, event)` to new state.
+//!
+//! [`Reducer`] operates on the full state. [`SliceReducer`] operates on an
+//! isolated slice and composes with peers via tuple syntax (up to arity 12).
+
 use crate::HasSlice;
 
 /// The output of a reducer.
@@ -8,34 +13,29 @@ pub struct ReducerOutput<S, E> {
     pub side_events: Option<Vec<E>>,
 }
 
-/// A reducer takes the current state and an event, and returns a [`ReducerOutput`]
-/// containing the new state and optionally side events to re-dispatch.
+/// A pure transformation: `(state, event)` → new state + optional side events.
 ///
-/// The reducer does not modify the state in place — it produces a new value
-/// that the [`crate::Store`] will use to replace the current state.
+/// The [`crate::Store`] replaces its state with the returned value; the
+/// input `&S` is not modified.
 pub trait Reducer<S> {
     /// The event type this reducer handles.
     type Event;
 
-    /// Computes a new state and optional side events from the current state and an event.
+    /// Computes the new state. Must be pure: no I/O, no mutation.
     fn reduce(&self, state: &S, event: &Self::Event) -> ReducerOutput<S, Self::Event>;
 }
 
-/// A reducer takes a slice of the current state and an event, and returns a [`ReducerOutput`]
-/// containing the new state slice and optionally side events to re-dispatch.
+/// Like [`Reducer`], but operates on a slice of the global state.
 ///
-/// The reducer does not modify the state slice in place — it produces a new value
-/// that the [`crate::Store`] will use to replace the current state slice.
-///
-/// Slice reducers are structurally isolated: the `reduce` method only receives
-/// `&Self::Slice`, making access to other slices impossible by construction.
+/// The `reduce` method receives `&Self::Slice` only, making access to other
+/// slices impossible by construction.
 pub trait SliceReducer {
     /// The event type this reducer handles.
     type Event;
     /// The slice of global state this reducer operates on.
     type Slice;
 
-    /// Computes a new state slice and optional side events from the current state and an event.
+    /// Computes the new slice. Must be pure: no I/O, no mutation.
     fn reduce(
         &self,
         slice: &Self::Slice,
@@ -43,17 +43,12 @@ pub trait SliceReducer {
     ) -> ReducerOutput<Self::Slice, Self::Event>;
 }
 
-/// Generates a `Reducer<S>` implementation for a tuple of [`SliceReducer`].
+/// Generates `Reducer<S>` for a tuple of [`SliceReducer`], invoked per arity.
 ///
-/// Invoked once per arity (1 through 12).
-///
-/// # Bounds generated
-///
-/// - `S: Clone` — the macro clones `&S` once at the start of `reduce` to chain
-///   `set_slice` calls
-/// - `Ri: SliceReducer<Event = E>` — all reducers in the tuple must share the
-///   same `Event` type
-/// - `S: HasSlice<Ri::Slice>` — required for each `Ri` to extract its slice
+/// Bounds generated:
+/// - `S: Clone` — `&S` is cloned once to chain `set_slice` calls
+/// - `Ri: SliceReducer<Event = E>` — shared `Event` type across the tuple
+/// - `S: HasSlice<Ri::Slice>` — required per `Ri` to extract its slice
 macro_rules! impl_slice_reducer_tuple {
     ($($idx:tt $t:ident),+) => {
         impl<S, E, $($t,)+> Reducer<S> for ($($t,)+)

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,6 @@
+//! State slice access. Required to compose [`crate::SliceReducer`] over a
+//! struct containing multiple slices.
+
 /// Gives access to a state slice for reading and update.
 pub trait HasSlice<T> {
     /// Returns a reference to the slice.

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,52 +1,77 @@
-use crate::reducer::{Reducer, ReducerOutput};
+//! Event-driven state container. The [`Store`] owns the state and the
+//! composed middleware chain, and exposes [`Store::dispatch`] as the only
+//! way to evolve the state.
+
+use crate::middleware::{Middleware, Next};
+use crate::reducer::Reducer;
 use std::collections::VecDeque;
 
-/// Errors that can occur during event dispatch.
+/// Errors returned by [`Store::dispatch`].
 #[derive(Debug, PartialEq)]
 pub enum DispatchError {
-    /// The maximum depth of events dispatching is exceeded
+    /// Side-event recursion exceeded `max_depth`.
     MaxDepthExceeded { depth: usize, max: usize },
 }
 
-/// An event pending for processing.
 struct PendingEvent<E> {
-    /// The actual event.
     event: E,
-    /// Depth in store dispatch call stack.
+    /// Re-dispatch depth (0 = original dispatch).
     depth: usize,
 }
 
-/// A typed state container that dispatches events through a reducer.
+/// A typed state container that dispatches events through a middleware
+/// chain and a reducer.
 ///
-/// The store owns the state and the reducer. State can only be modified
-/// by dispatching events, ensuring a predictable unidirectional data flow.
-pub struct Store<S, R, E> {
+/// State changes only via [`dispatch`](Store::dispatch). The reducer is
+/// the sole producer of new state; middlewares observe, transform, or
+/// short-circuit the flow.
+pub struct Store<S, E> {
     state: S,
-    reducer: R,
     queue: VecDeque<PendingEvent<E>>,
-
+    chain: Next<S, E>,
     max_depth: usize,
 }
 
-impl<S, R: Reducer<S, Event = E>, E> Store<S, R, E> {
-    /// Creates a new store with the given initial state and reducer.
-    pub fn new(state: S, reducer: R, max_depth: usize) -> Self {
+impl<S, E> Store<S, E> {
+    /// Builds a store from an initial state, a reducer, and an ordered list
+    /// of middlewares (see [`crate::middleware`] for the composition order).
+    ///
+    /// `max_depth` bounds the side-event re-dispatch depth (original dispatch
+    /// is depth 0). An event at depth `max_depth` may run but cannot emit
+    /// further side events.
+    pub fn new<R>(
+        state: S,
+        reducer: R,
+        middlewares: Vec<Box<dyn Middleware<S, E>>>,
+        max_depth: usize,
+    ) -> Self
+    where
+        R: Reducer<S, Event = E> + 'static,
+        S: 'static,
+        E: 'static,
+    {
+        let base = Box::new(move |state: &mut S, event: E| -> Option<Vec<E>> {
+            let output = reducer.reduce(state, &event);
+            *state = output.state;
+            output.side_events
+        });
         Store {
             state,
-            reducer,
+            chain: middlewares
+                .into_iter()
+                .rev()
+                .fold(base, |res, mid| mid.wrap(res)),
             queue: VecDeque::new(),
             max_depth,
         }
     }
 
-    /// Dispatches an event through the reducer, updating the state.
-    ///
-    /// Side events produced by the reducer are automatically re-dispatched
-    /// in FIFO order. Returns an error if the re-dispatch depth exceeds
-    /// `max_depth`.
-    pub fn dispatch(&mut self, event: R::Event) -> Result<(), DispatchError> {
-        let output = self.reducer.reduce(&self.state, &event);
-        self.apply_output(output, 0)?;
+    /// Dispatches an event through the chain. Side events are re-dispatched
+    /// in FIFO order; errors with [`DispatchError::MaxDepthExceeded`] when
+    /// recursion exceeds `max_depth`.
+    pub fn dispatch(&mut self, event: E) -> Result<(), DispatchError> {
+        let events = (self.chain)(&mut self.state, event);
+        self.queue_side_events(events, 0)?;
 
         while let Some(pending) = self.queue.pop_front() {
             self.internal_dispatch(pending)?
@@ -59,13 +84,12 @@ impl<S, R: Reducer<S, Event = E>, E> Store<S, R, E> {
         &self.state
     }
 
-    fn apply_output(
+    fn queue_side_events(
         &mut self,
-        output: ReducerOutput<S, R::Event>,
+        events: Option<Vec<E>>,
         current_depth: usize,
     ) -> Result<(), DispatchError> {
-        self.state = output.state;
-        if let Some(events) = output.side_events {
+        if let Some(events) = events {
             if current_depth >= self.max_depth {
                 return Err(DispatchError::MaxDepthExceeded {
                     depth: current_depth,
@@ -83,197 +107,382 @@ impl<S, R: Reducer<S, Event = E>, E> Store<S, R, E> {
         Ok(())
     }
 
-    fn internal_dispatch(
-        &mut self,
-        pending_event: PendingEvent<R::Event>,
-    ) -> Result<(), DispatchError> {
+    fn internal_dispatch(&mut self, pending_event: PendingEvent<E>) -> Result<(), DispatchError> {
         let event = pending_event.event;
-        let output = self.reducer.reduce(&self.state, &event);
-        self.apply_output(output, pending_event.depth)
+        let events = (self.chain)(&mut self.state, event);
+        self.queue_side_events(events, pending_event.depth)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::reducer::{Reducer, ReducerOutput};
-    use crate::store::tests::Event::{
-        EmitNestedSide, EmitSelfRecursive, EmitSide, FirstValueUpdate, IgnoredUpdate,
-        SecondValueUpdate,
-    };
-    use crate::store::{DispatchError, Store};
 
-    enum Event {
-        FirstValueUpdate { value: f64 },
-        SecondValueUpdate { value: u32 },
-        IgnoredUpdate {},
-        EmitSide {},
-        EmitNestedSide {},
-        EmitSelfRecursive {},
-    }
+    mod fixtures {
+        use crate::{Reducer, ReducerOutput, Store};
+        use Event::*;
+        pub(super) enum Event {
+            FirstValueUpdate { value: f64 },
+            SecondValueUpdate { value: u32 },
+            IgnoredUpdate {},
+            EmitSide {},
+            EmitNestedSide {},
+            EmitSelfRecursive {},
+        }
 
-    #[derive(Clone, Debug, PartialEq)]
-    struct SimpleState {
-        first_value: f64,
-        second_value: u32,
-    }
+        #[derive(Clone, Debug, PartialEq)]
+        pub(super) struct SimpleState {
+            pub(super) first_value: f64,
+            pub(super) second_value: u32,
+        }
 
-    struct SimpleReducer {}
+        pub(super) struct SimpleReducer {}
 
-    impl Reducer<SimpleState> for SimpleReducer {
-        type Event = Event;
+        impl Reducer<SimpleState> for SimpleReducer {
+            type Event = Event;
 
-        fn reduce(
-            &self,
-            state: &SimpleState,
-            event: &Self::Event,
-        ) -> ReducerOutput<SimpleState, Event> {
-            match event {
-                FirstValueUpdate { value } => ReducerOutput {
-                    state: SimpleState {
-                        first_value: *value,
-                        ..*state
+            fn reduce(
+                &self,
+                state: &SimpleState,
+                event: &Self::Event,
+            ) -> ReducerOutput<SimpleState, Event> {
+                match event {
+                    FirstValueUpdate { value } => ReducerOutput {
+                        state: SimpleState {
+                            first_value: *value,
+                            ..*state
+                        },
+                        side_events: None,
                     },
-                    side_events: None,
-                },
-                SecondValueUpdate { value } => ReducerOutput {
-                    state: SimpleState {
-                        second_value: *value,
-                        ..*state
+                    SecondValueUpdate { value } => ReducerOutput {
+                        state: SimpleState {
+                            second_value: *value,
+                            ..*state
+                        },
+                        side_events: None,
                     },
-                    side_events: None,
-                },
-                EmitSide {} => ReducerOutput {
-                    state: state.clone(),
-                    side_events: Some(vec![SecondValueUpdate { value: 2 }, IgnoredUpdate {}]),
-                },
-                EmitNestedSide {} => ReducerOutput {
-                    state: state.clone(),
-                    side_events: Some(vec![EmitSide {}, FirstValueUpdate { value: 2.0 }]),
-                },
-                EmitSelfRecursive {} => ReducerOutput {
-                    state: state.clone(),
-                    side_events: Some(vec![EmitSelfRecursive {}]),
-                },
-                _ => ReducerOutput {
-                    state: state.clone(),
-                    side_events: None,
-                },
+                    EmitSide {} => ReducerOutput {
+                        state: state.clone(),
+                        side_events: Some(vec![SecondValueUpdate { value: 2 }, IgnoredUpdate {}]),
+                    },
+                    EmitNestedSide {} => ReducerOutput {
+                        state: state.clone(),
+                        side_events: Some(vec![EmitSide {}, FirstValueUpdate { value: 2.0 }]),
+                    },
+                    EmitSelfRecursive {} => ReducerOutput {
+                        state: state.clone(),
+                        side_events: Some(vec![EmitSelfRecursive {}]),
+                    },
+                    _ => ReducerOutput {
+                        state: state.clone(),
+                        side_events: None,
+                    },
+                }
             }
+        }
+
+        pub(super) fn make_state() -> SimpleState {
+            SimpleState {
+                first_value: 1.5,
+                second_value: 3,
+            }
+        }
+
+        pub(super) fn make_store() -> Store<SimpleState, Event> {
+            let reducer = SimpleReducer {};
+            Store::new(make_state(), reducer, vec![], 10)
         }
     }
 
-    fn make_state() -> SimpleState {
-        SimpleState {
-            first_value: 1.5,
-            second_value: 3,
+    mod basic_dispatch {
+        use super::fixtures::Event::*;
+        use super::fixtures::*;
+
+        #[test]
+        fn initial_state() {
+            let store = make_store();
+            let state = make_state();
+
+            assert_eq!(*store.state(), state);
+        }
+
+        #[test]
+        fn single_dispatch() {
+            let mut store = make_store();
+            let state = make_state();
+
+            store
+                .dispatch(FirstValueUpdate { value: 1.2 })
+                .expect("dispatch failed");
+            assert_eq!(
+                *store.state(),
+                SimpleState {
+                    first_value: 1.2,
+                    ..state
+                }
+            );
+        }
+
+        #[test]
+        fn multiple_dispatch() {
+            let mut store = make_store();
+            let state = make_state();
+
+            store
+                .dispatch(FirstValueUpdate { value: 1.2 })
+                .expect("Should not panic");
+            assert_eq!(
+                *store.state(),
+                SimpleState {
+                    first_value: 1.2,
+                    ..state
+                }
+            );
+
+            let state = store.state().clone();
+            store
+                .dispatch(SecondValueUpdate { value: 5 })
+                .expect("Should not panic");
+            assert_eq!(
+                *store.state(),
+                SimpleState {
+                    second_value: 5,
+                    ..state
+                }
+            );
+        }
+
+        #[test]
+        fn unrelated_dispatch() {
+            let mut store = make_store();
+            let state = make_state();
+
+            store.dispatch(IgnoredUpdate {}).expect("Should not panic");
+            assert_eq!(*store.state(), state);
         }
     }
 
-    fn make_store() -> Store<SimpleState, SimpleReducer, Event> {
-        let reducer = SimpleReducer {};
-        let state = make_state();
-        Store::new(state.clone(), reducer, 10)
+    mod side_events {
+        use super::fixtures::Event::*;
+        use super::fixtures::*;
+        use crate::store::DispatchError;
+        #[test]
+        fn side_event_dispatch() {
+            let mut store = make_store();
+            let state = make_state();
+
+            store.dispatch(EmitSide {}).expect("Should not panic");
+            assert_eq!(
+                *store.state(),
+                SimpleState {
+                    second_value: 2,
+                    ..state
+                }
+            )
+        }
+
+        #[test]
+        fn multiple_side_event_dispatch() {
+            let mut store = make_store();
+
+            store.dispatch(EmitNestedSide {}).expect("Should not panic");
+            assert_eq!(
+                *store.state(),
+                SimpleState {
+                    first_value: 2.0,
+                    second_value: 2,
+                }
+            )
+        }
+
+        #[test]
+        fn max_depth_dispatch() {
+            let mut store = make_store();
+
+            let err = store
+                .dispatch(EmitSelfRecursive {})
+                .expect_err("Should return an error");
+            assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 10, max: 10 });
+        }
     }
 
-    #[test]
-    fn initial_state() {
-        let store = make_store();
-        let state = make_state();
+    mod middlewares {
+        use super::fixtures::Event::*;
+        use super::fixtures::{Event, SimpleState, make_state};
+        use crate::Middleware;
+        use fixtures::*;
+        use std::rc::Rc;
 
-        assert_eq!(*store.state(), state);
-    }
+        mod fixtures {
+            use super::super::fixtures::{Event, SimpleReducer, SimpleState, make_state};
+            use crate::{Middleware, Next, Store};
+            use std::cell::RefCell;
+            use std::marker::PhantomData;
+            use std::rc::Rc;
 
-    #[test]
-    fn single_dispatch() {
-        let mut store = make_store();
-        let state = make_state();
-
-        store
-            .dispatch(FirstValueUpdate { value: 1.2 })
-            .expect("dispatch failed");
-        assert_eq!(
-            *store.state(),
-            SimpleState {
-                first_value: 1.2,
-                ..state
+            pub(super) struct Logger {
+                pub logs: Vec<String>,
             }
-        );
-    }
 
-    #[test]
-    fn multiple_dispatch() {
-        let mut store = make_store();
-        let state = make_state();
+            impl Logger {
+                fn new() -> Self {
+                    Self { logs: vec![] }
+                }
 
-        store
-            .dispatch(FirstValueUpdate { value: 1.2 })
-            .expect("Should not panic");
-        assert_eq!(
-            *store.state(),
-            SimpleState {
-                first_value: 1.2,
-                ..state
+                pub(super) fn log(&mut self, msg: impl Into<String>) {
+                    self.logs.push(msg.into());
+                }
             }
-        );
 
-        let state = store.state().clone();
-        store
-            .dispatch(SecondValueUpdate { value: 5 })
-            .expect("Should not panic");
-        assert_eq!(
-            *store.state(),
-            SimpleState {
-                second_value: 5,
-                ..state
+            pub(super) fn make_shared_logger() -> Rc<RefCell<Logger>> {
+                Rc::new(RefCell::new(Logger::new()))
             }
-        );
-    }
 
-    #[test]
-    fn unrelated_dispatch() {
-        let mut store = make_store();
-        let state = make_state();
-
-        store.dispatch(IgnoredUpdate {}).expect("Should not panic");
-        assert_eq!(*store.state(), state);
-    }
-
-    #[test]
-    fn side_event_dispatch() {
-        let mut store = make_store();
-        let state = make_state();
-
-        store.dispatch(EmitSide {}).expect("Should not panic");
-        assert_eq!(
-            *store.state(),
-            SimpleState {
-                second_value: 2,
-                ..state
+            pub(super) struct ProbeMiddleware<S, E> {
+                pre: Box<dyn FnMut(&S)>,
+                post: Box<dyn FnMut(&S)>,
+                _marker: PhantomData<E>,
             }
-        )
-    }
 
-    #[test]
-    fn multiple_side_event_dispatch() {
-        let mut store = make_store();
-
-        store.dispatch(EmitNestedSide {}).expect("Should not panic");
-        assert_eq!(
-            *store.state(),
-            SimpleState {
-                first_value: 2.0,
-                second_value: 2,
+            impl<S, E> ProbeMiddleware<S, E> {
+                pub(super) fn new(pre: Box<dyn FnMut(&S)>, post: Box<dyn FnMut(&S)>) -> Self {
+                    Self {
+                        pre,
+                        post,
+                        _marker: PhantomData,
+                    }
+                }
             }
-        )
-    }
 
-    #[test]
-    fn max_depth_dispatch() {
-        let mut store = make_store();
+            impl Middleware<SimpleState, Event> for ProbeMiddleware<SimpleState, Event> {
+                fn wrap(
+                    mut self: Box<Self>,
+                    mut next: Next<SimpleState, Event>,
+                ) -> Next<SimpleState, Event> {
+                    Box::new(move |state, event| {
+                        (self.pre)(state);
+                        let output = next(state, event);
+                        (self.post)(state);
+                        output
+                    })
+                }
+            }
 
-        let err = store
-            .dispatch(EmitSelfRecursive {})
-            .expect_err("Should return an error");
-        assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 10, max: 10 });
+            pub(super) struct ShortCircuitMiddleware {}
+
+            impl Middleware<SimpleState, Event> for ShortCircuitMiddleware {
+                fn wrap(self: Box<Self>, _: Next<SimpleState, Event>) -> Next<SimpleState, Event> {
+                    Box::new(|_, _| None)
+                }
+            }
+
+            pub(super) fn make_store(
+                middlewares: Vec<Box<dyn Middleware<SimpleState, Event>>>,
+            ) -> Store<SimpleState, Event> {
+                let reducer = SimpleReducer {};
+                Store::new(make_state(), reducer, middlewares, 10)
+            }
+        }
+
+        #[test]
+        fn onion_order() {
+            let logger = make_shared_logger();
+            let push_msg = |msg: &'static str| -> Box<dyn FnMut(&SimpleState)> {
+                let logger_copy = Rc::clone(&logger);
+                Box::new(move |_| logger_copy.borrow_mut().log(msg))
+            };
+
+            let middlewares: Vec<Box<dyn Middleware<SimpleState, Event>>> = vec![
+                Box::new(ProbeMiddleware::<SimpleState, Event>::new(
+                    push_msg("Pre-Middleware1"),
+                    push_msg("Post-Middleware1"),
+                )),
+                Box::new(ProbeMiddleware::<SimpleState, Event>::new(
+                    push_msg("Pre-Middleware2"),
+                    push_msg("Post-Middleware2"),
+                )),
+            ];
+
+            let mut store = make_store(middlewares);
+
+            store
+                .dispatch(FirstValueUpdate { value: 1.2 })
+                .expect("dispatch failed");
+
+            assert_eq!(
+                *logger.borrow().logs,
+                vec![
+                    "Pre-Middleware1",
+                    "Pre-Middleware2",
+                    "Post-Middleware2",
+                    "Post-Middleware1",
+                ]
+            )
+        }
+        #[test]
+        fn inspect_state_pre_post_dispatch() {
+            let logger = make_shared_logger();
+            let inspect_state = |step: &'static str| -> Box<dyn FnMut(&SimpleState)> {
+                let logger_copy = Rc::clone(&logger);
+                Box::new(move |state| {
+                    logger_copy
+                        .borrow_mut()
+                        .log(format!("First value {}: {}", step, state.first_value))
+                })
+            };
+
+            let middlewares: Vec<Box<dyn Middleware<SimpleState, Event>>> =
+                vec![Box::new(ProbeMiddleware::<SimpleState, Event>::new(
+                    inspect_state("before dispatch"),
+                    inspect_state("after dispatch"),
+                ))];
+
+            let mut store = make_store(middlewares);
+
+            store
+                .dispatch(FirstValueUpdate { value: 1.2 })
+                .expect("dispatch failed");
+
+            assert_eq!(
+                *logger.borrow().logs,
+                vec![
+                    "First value before dispatch: 1.5",
+                    "First value after dispatch: 1.2",
+                ]
+            )
+        }
+
+        #[test]
+        fn short_circuit() {
+            let logger = make_shared_logger();
+            let push_msg = |msg: &'static str| -> Box<dyn FnMut(&SimpleState)> {
+                let logger_copy = Rc::clone(&logger);
+                Box::new(move |_| logger_copy.borrow_mut().log(msg))
+            };
+
+            let middlewares: Vec<Box<dyn Middleware<SimpleState, Event>>> = vec![
+                Box::new(ProbeMiddleware::<SimpleState, Event>::new(
+                    push_msg("Pre-Middleware1"),
+                    push_msg("Post-Middleware1"),
+                )),
+                Box::new(ShortCircuitMiddleware {}),
+                Box::new(ProbeMiddleware::<SimpleState, Event>::new(
+                    push_msg("Pre-Middleware2"),
+                    push_msg("Post-Middleware2"),
+                )),
+            ];
+
+            let mut store = make_store(middlewares);
+
+            store
+                .dispatch(FirstValueUpdate { value: 1.2 })
+                .expect("dispatch failed");
+
+            assert_eq!(
+                *logger.borrow().logs,
+                vec!["Pre-Middleware1", "Post-Middleware1",]
+            );
+
+            assert_eq!(*store.state(), make_state());
+        }
     }
 }


### PR DESCRIPTION
Closes #6.

## Summary

- `Middleware<S, E>` trait with onion-model composition (first middleware = outermost)
- `Next<S, E>` type alias for the composed dispatch chain
- `Store` refactored to mutate state in place during the chain (post-phase sees updated state)
- `examples/middleware.rs` demonstrating a counter + custom logging middleware

## Architectural choices

- `&mut S` in the chain (rather than `&S` + snapshot) so post-phase observes the post-reducer state without explicit plumbing
- `Vec<Box<dyn Middleware>>` for the chain (heterogeneous collection); tuple-based composition deferred
- Reducer stays pure: the `base` closure in `Store::new` bridges the in-place mutation

## Tests

- Onion order across a 2-middleware chain
- Pre/post state inspection
- Short-circuit (skipping `next`): state unchanged, inner chain skipped
- All previous Store tests preserved, reorganized into `basic_dispatch` / `side_events` / `middlewares` sub-modules

## Follow-ups

- #21 — migrate tests to `tests/` directory for strict public API enforcement
- #15 — comprehensive docs (Mermaid diagrams, README, architecture)