### PR TITLE
docs: MVP documentation and EMS example

### DIFF
--- a/.claude/rules/learning-mode.md
+++ b/.claude/rules/learning-mode.md
@@ -20,6 +20,10 @@ role is to **validate, challenge, explain, and document** — not to implement.
 - **Implement features** — unless the user explicitly says "write this for me"
 - **Design solutions** — Claude challenges the user's design, doesn't create one
 - **Write code proactively** — no unsolicited implementations, even "small helpers"
+- **Design or implement code in `examples/`** — example programs are Rust code; treat
+  them like any other implementation (challenge the user's design, review the code,
+  but do not propose field names, event variants, or scenarios on Claude's own
+  initiative)
 - **Invoke skills proactively** — wait for the user to ask
 
 ## When the User is Stuck
@@ -34,10 +38,11 @@ Follow this escalation:
 
 ## Anti-Patterns
 
-| Anti-Pattern                        | Correct Approach                        |
-| ----------------------------------- | --------------------------------------- |
-| Writing implementation code         | Challenge design, explain concepts      |
-| Designing the solution              | Ask questions to guide the user's design|
-| "Let me implement this for you"     | "What approach are you considering?"    |
-| Proactively invoking `/commit`      | Wait for the user to ask                |
-| Giving the answer when user is stuck| Give hints, escalate gradually          |
+| Anti-Pattern                          | Correct Approach                          |
+| ------------------------------------- | ----------------------------------------- |
+| Writing implementation code           | Challenge design, explain concepts        |
+| Designing the solution                | Ask questions to guide the user's design  |
+| "Let me implement this for you"       | "What approach are you considering?"      |
+| Drafting an `examples/` scenario      | Ask the user to design and implement it   |
+| Proactively invoking `/commit`        | Wait for the user to ask                  |
+| Giving the answer when user is stuck  | Give hints, escalate gradually            |

--- a/.claude/skills/validate-design/SKILL.md
+++ b/.claude/skills/validate-design/SKILL.md
@@ -48,6 +48,32 @@ Ask the user probing questions:
 **Do NOT propose a complete alternative design.** Ask questions that guide the user to
 discover improvements themselves.
 
+#### Separate design feedback from implementation feedback
+
+A design draft is **not** finished code. The user is exploring shape, not polishing
+syntax. Mixing the two levels dilutes the review and frustrates the user.
+
+When reviewing a design, classify each remark into one of two buckets:
+
+- **Design-level** (semantic, structural, conceptual) — wrong trait usage, wrong
+  abstraction boundary, missing concept, pedagogical mismatch. **These are the
+  review.**
+- **Implementation-level** (compile errors, missing derives, typos, naming
+  placeholders, non-exhaustive matches, position of doc comments) — will be caught
+  by the compiler or `cargo check` at implementation time.
+
+Implementation-level remarks should be either:
+
+1. **Omitted entirely** during the design phase — the compiler will surface them, no
+   value added by listing them now
+2. **Or grouped at the end** under a clearly-labeled section like *"Nits à corriger à
+   l'implem (pas bloquant pour le design)"* — so the user can ignore them during the
+   design iteration
+
+Never interleave a design question with a "you forgot `#[derive(Clone)]`" remark in the
+same priority bucket. The design question carries the cost of an iteration; the missing
+derive carries the cost of a compiler hint.
+
 ### Phase 3: Formalize
 
 Once the user has addressed the challenges, produce:
@@ -75,10 +101,11 @@ rm <number>_draft.md
 
 ## Anti-Patterns
 
-| Anti-Pattern                    | Correct Approach                         |
-| ------------------------------- | ---------------------------------------- |
-| Proposing a full design         | Ask questions to improve the user's      |
-| Skipping challenges             | Always challenge before formalizing       |
-| Writing implementation code     | Only show trait signatures, not bodies    |
+| Anti-Pattern                                | Correct Approach                                  |
+| ------------------------------------------- | ------------------------------------------------- |
+| Proposing a full design                     | Ask questions to improve the user's               |
+| Skipping challenges                         | Always challenge before formalizing               |
+| Writing implementation code                 | Only show trait signatures, not bodies            |
+| Mixing design + compile-error feedback      | Separate buckets; omit or footnote impl-level     |
 
 $ARGUMENTS

--- a/README.md
+++ b/README.md
@@ -1,65 +1,125 @@
 # ruxe
 
-[Redux](https://redux.js.org/)-inspired state management library for Rust with
-compile-time safe parallel reducers on isolated state slices.
+[Redux](https://redux.js.org/)-inspired state management library for Rust with compile-time safe parallel reducers on isolated state slices.
 
 ## Why ruxe?
 
-Existing Rust Redux implementations (redux-rs, rust_redux) lack key features:
-RootReducer, SliceReducer, and parallel execution. ruxe fills that gap by leveraging
-Rust's ownership model — not as a constraint, but as a feature — to guarantee
-data-race-free parallel reducers at compile time.
+Existing Rust Redux implementations (redux-rs, rust_redux) lack key features: RootReducer, SliceReducer, and parallel execution. ruxe fills that gap by leveraging Rust's ownership model — not as a constraint, but as a feature — to guarantee data-race-free parallel reducers at compile time.
+
+## Quick start
+
+```rust
+use ruxe::{Reducer, ReducerOutput, Store};
+
+// 1. Define your state. It must be `Clone`.
+#[derive(Clone)]
+struct Counter {
+    value: i32,
+}
+
+// 2. Define events as a typed enum — no stringly-typed actions.
+enum Event {
+    Increment,
+    Decrement,
+}
+
+// 3. A reducer is a pure `(state, event) -> new state` transformation.
+struct CounterReducer;
+
+impl Reducer<Counter> for CounterReducer {
+    type Event = Event;
+
+    fn reduce(&self, state: &Counter, event: &Event) -> ReducerOutput<Counter, Event> {
+        let value = match event {
+            Event::Increment => state.value + 1,
+            Event::Decrement => state.value - 1,
+        };
+        ReducerOutput {
+            state: Counter { value },
+            side_events: None,
+        }
+    }
+}
+
+fn main() {
+    // No middlewares; cap side-event re-dispatch depth at 8.
+    let mut store = Store::new(Counter { value: 0 }, CounterReducer, vec![], 8);
+
+    store.dispatch(Event::Increment).unwrap();
+    store.dispatch(Event::Increment).unwrap();
+    store.dispatch(Event::Decrement).unwrap();
+
+    assert_eq!(store.state().value, 1);
+}
+```
+
+For a realistic multi-slice setup with middlewares and side events, see [`examples/ems_sequential.rs`](examples/ems_sequential.rs) — a mini Energy Management System composing three independent state slices (solar, battery, grid meter).
 
 ## Design
 
+```mermaid
+classDiagram
+    class Store~S, E~ {
+        +new(state, reducer, middlewares, max_depth)
+        +dispatch(event) Result
+        +state() &S
+    }
+    class Reducer~S~ {
+        <<trait>>
+        +reduce(state, event) ReducerOutput
+    }
+    class SliceReducer {
+        <<trait>>
+        +reduce(slice, event) ReducerOutput
+    }
+    class HasSlice~T~ {
+        <<trait>>
+        +slice() &T
+        +set_slice(T) Self
+    }
+    class ReducerOutput~S, E~ {
+        +state: S
+        +side_events: Option~Vec~E~~
+    }
+    class Middleware~S, E~ {
+        <<trait>>
+        +wrap(next) Next
+    }
+
+    Store --> Reducer : drives
+    Store --> Middleware : composes (onion)
+    Reducer ..> ReducerOutput : returns
+    SliceReducer ..> ReducerOutput : returns
+    HasSlice ..> SliceReducer : exposes a slice to
 ```
-Store<S, R>            Generic state container
-Reducer<S>             Trait with associated Event type — operates on full state
-SliceReducer           Trait with associated Slice + Event — operates on a state slice
-HasSlice<T>            Bridges a slice to the global state (user-implemented)
-ReducerOutput<S, E>    Return type: new state + optional side events
-RootReducer            Combines slice reducers (planned)
-Middleware             Pre/post dispatch hooks (planned)
-ParallelRootReducer    Rayon-based parallel execution (planned)
-```
 
-### Core API
+A tuple `(R1, R2, …)` of `SliceReducer`s is itself a `Reducer<S>` (given `S: HasSlice<Ri::Slice>`), so slice reducers compose into a root reducer with no glue code. `Next<S, E>` is the dispatch-chain closure each middleware wraps, and `DispatchError` is returned when side-event recursion exceeds the configured depth. Parallel composition (`ParallelRootReducer`, rayon-based) is planned.
 
-```rust
-pub trait Reducer<S> {
-    type Event;
-    fn reduce(&self, state: &S, event: &Self::Event) -> ReducerOutput<S, Self::Event>;
-}
-
-pub trait SliceReducer {
-    type Event;
-    type Slice;
-    fn reduce(
-        &self,
-        slice: &Self::Slice,
-        event: &Self::Event,
-    ) -> ReducerOutput<Self::Slice, Self::Event>;
-}
-
-pub trait HasSlice<T> {
-    fn slice(&self) -> &T;
-    fn set_slice(self, slice: T) -> Self;
-}
-
-pub struct Store<S, R> { /* ... */ }
-
-impl<S, R: Reducer<S>> Store<S, R> {
-    pub fn new(state: S, reducer: R) -> Self;
-    pub fn dispatch(&mut self, event: R::Event);
-    pub fn state(&self) -> &S;
-}
-```
+For exact signatures, trait bounds, and runnable examples, see the rustdoc — run `cargo doc --open` (it will be published on docs.rs once ruxe ships to crates.io).
 
 ### Events, not Actions
 
-Redux uses the term "action" for messages dispatched to the store. ruxe uses **event**
-instead — a better fit for embedded/IoT contexts where state changes are often triggered
-by external signals (sensor readings, price updates, timer ticks), not user interactions.
+Redux uses the term "action" for messages dispatched to the store. ruxe uses **event** instead — a better fit for embedded/IoT contexts where state changes are often triggered by external signals (sensor readings, price updates, timer ticks), not user interactions.
+
+## Comparison with redux-rs
+
+[redux-rs](https://github.com/redux-rs/redux-rs) is the most established Redux port for Rust. The two libraries make different tradeoffs:
+
+| Aspect                     | redux-rs                                            | ruxe                                                        |
+| -------------------------- | --------------------------------------------------- | ----------------------------------------------------------- |
+| Message term               | `Action`                                            | `Event`                                                     |
+| State structure            | single state; every reducer sees all of it          | isolated slices — a `SliceReducer` can only reach its slice |
+| Root composition           | one reducer combines everything by hand             | a tuple of `SliceReducer`s *is* a `Reducer`, no glue code   |
+| Reducer input              | `state: State` (owned, mutate-and-return, no clone) | `state: &S` (borrowed; reducer returns a fresh state)       |
+| Side events in reducer     | none — reducers are pure `state → state`            | reducers may emit side events, re-dispatched by the store   |
+| Side effects in middleware | yes — re-dispatch via `inner.dispatch().await`      | yes — return side events that the store queues              |
+| Execution model            | async-native, requires Tokio                        | synchronous, runtime-agnostic (async planned)               |
+| Concurrency                | lock-free multi-producer dispatch via a worker task | single-owner `&mut self`, sequential                        |
+| Middleware registration    | manual `.wrap(m).await` chain, separate store type  | passed to `Store::new` (empty `vec` to opt out)             |
+| Selectors                  | built-in (`select`, memoized state queries)         | none — slices are accessed directly via `HasSlice`          |
+| Parallel reducers          | no                                                  | planned (`ParallelRootReducer`, rayon-based)                |
+
+In short: redux-rs is async-first and ships more batteries (selectors, Tokio integration); ruxe trades those for **compile-time slice isolation**, **side events straight from reducers**, and a **runtime-agnostic synchronous core** that you wrap in whatever execution model you need.
 
 ## Roadmap
 
@@ -68,8 +128,8 @@ by external signals (sensor readings, price updates, timer ticks), not user inte
 | 1 — MVP | [Store, Event, Reducer][i2]        | done    |
 | 1       | [ReducerOutput][i3]                | done    |
 | 1       | [SliceReducer][i4]                 | done    |
-| 1       | [Sequential RootReducer][i5]       | done |
-| 1       | [Middleware][i6]                    | done |
+| 1       | [Sequential RootReducer][i5]       | done    |
+| 1       | [Middleware][i6]                   | done    |
 | 1       | [Documentation & EMS example][i7]  | planned |
 | 2       | [Parallel RootReducer (rayon)][i8] | planned |
 | 2       | [Benchmarks][i9]                   | planned |
@@ -83,30 +143,19 @@ by external signals (sensor readings, price updates, timer ticks), not user inte
 [i8]: https://github.com/corentin-core/ruxe/issues/8
 [i9]: https://github.com/corentin-core/ruxe/issues/9
 
-See [the project epic](https://github.com/corentin-core/ruxe/issues/1) for the full
-design and task breakdown.
+See [the project epic](https://github.com/corentin-core/ruxe/issues/1) for the full design and task breakdown.
 
-> **Note on parallel reducers**: classic Redux is strictly sequential — each reducer sees
-> the previous one's changes, making state transitions predictable and easy to debug.
-> Parallel reducers trade that guarantee for performance by giving each reducer a frozen
-> snapshot of the state before dispatch. This is arguably an anti-pattern in the Redux
-> sense, but it's an interesting space to explore in performance-sensitive or embedded
-> contexts where state slices are truly independent. ruxe treats it as an opt-in
-> experiment, not a default.
+> **Note on parallel reducers**: classic Redux is strictly sequential — each reducer sees the previous one's changes, making state transitions predictable and easy to debug. Parallel reducers trade that guarantee for performance by giving each reducer a frozen snapshot of the state before dispatch. This is arguably an anti-pattern in the Redux sense, but it's an interesting space to explore in performance-sensitive or embedded contexts where state slices are truly independent. ruxe treats it as an opt-in experiment, not a default.
 
 ## A learning project
 
-ruxe is built as a Rust learning project. The code is written by hand — Claude Code is
-configured in **learning mode**: it reviews, challenges, and explains, but does not write
-implementation code.
+ruxe is built as a Rust learning project. The code is written by hand — Claude Code is configured in **learning mode**: it reviews, challenges, and explains, but does not write implementation code.
 
 The Claude configuration showcasing this workflow is tracked in the repo:
 
 - [`CLAUDE.md`](CLAUDE.md) — project instructions and learning workflow
-- [`.claude/rules/learning-mode.md`](.claude/rules/learning-mode.md) — behavioral
-  constraints (what Claude does and doesn't do)
-- [`.claude/skills/validate-design/`](.claude/skills/validate-design/) — design
-  validation skill
+- [`.claude/rules/learning-mode.md`](.claude/rules/learning-mode.md) — behavioral constraints (what Claude does and doesn't do)
+- [`.claude/skills/validate-design/`](.claude/skills/validate-design/) — design validation skill
 
 ## License
 

--- a/examples/ems_sequential.rs
+++ b/examples/ems_sequential.rs
@@ -1,0 +1,443 @@
+//! A sequential Energy Management System (EMS) built on ruxe.
+//!
+//! An EMS supervises a power installation. This example models a small plant
+//! with three independent subsystems, each held as a state slice:
+//!
+//! - **Solar** — a PV inverter producing power
+//! - **Battery** — stores and releases energy; tracks a state of charge (SOC)
+//! - **Power meter** — measures the plant's exchange with the grid
+//!
+//! Units: active power in watts (W), reactive power in volt-amperes reactive
+//! (VAR), voltage in volts (V), state of charge as a percentage (%).
+//!
+//! ## What it demonstrates
+//!
+//! - A `PlantState` composed of 3 isolated slices, each with its own
+//!   [`SliceReducer`], combined into a root reducer via tuple syntax
+//! - Typed events (an `enum`) rather than stringly-typed actions
+//! - Two middlewares: a logger that traces every event and state, and a
+//!   battery controller that reacts to a fact by issuing a command
+//! - Side events emitted from **both** a reducer and a middleware, then
+//!   re-dispatched by the store
+//!
+//! ## Scenario
+//!
+//! Three telemetry events are dispatched (solar, battery, power-meter updates).
+//! The battery update drops the SOC to 10%: the battery reducer detects the
+//! threshold breach and emits `BatteryStateOfChargeLow` as a side event. The
+//! control middleware observes that fact and emits a `BatteryCommand` that
+//! zeroes the battery's output — showing reducers and middlewares cooperating
+//! through the event queue without ever touching each other's slice.
+//!
+//! Run with: `cargo run --example ems_sequential`
+//!
+//! Expected output:
+//! ```text
+//! EMS Sequential Example
+//! Event received: SolarUpdate: 100.0W, 50.0VAR, 240.0V
+//! Current state: Solar: 0.0W, 0.0VAR, 0.0V, Battery: 100.0%, 0.0W, 0.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! New state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 100.0%, 0.0W, 0.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! Event received: BatteryUpdate: 10.0%, 50.0W, 25.0VAR
+//! Current state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 100.0%, 0.0W, 0.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! New state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 50.0W, 25.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! Event received: BatteryStateOfChargeLow
+//! Current state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 50.0W, 25.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! Battery state of charge is low. Activating battery control.
+//! Issuing command: BatteryCommand: 0.0W, 0.0VAR to reduce battery output.
+//! New state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 50.0W, 25.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! Event received: BatteryCommand: 0.0W, 0.0VAR
+//! Current state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 50.0W, 25.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! New state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 0.0W, 0.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! Event received: PowerMeterUpdate: 150.0W, 75.0VAR, 240.0V
+//! Current state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 0.0W, 0.0VAR, Power Meter: 0.0W, 0.0VAR, 0.0V
+//! New state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 0.0W, 0.0VAR, Power Meter: 150.0W, 75.0VAR, 240.0V
+//! Final state: Solar: 100.0W, 50.0VAR, 240.0V, Battery: 10.0%, 0.0W, 0.0VAR, Power Meter: 150.0W, 75.0VAR, 240.0V
+//! ```
+
+use std::fmt::Display;
+
+use ruxe::{HasSlice, Middleware, Next, Reducer, ReducerOutput, SliceReducer, Store};
+
+#[derive(Clone)]
+struct SolarState {
+    active_power: f64,
+    reactive_power: f64,
+    voltage: f64,
+}
+
+impl Display for SolarState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:.1}W, {:.1}VAR, {:.1}V",
+            self.active_power, self.reactive_power, self.voltage
+        )
+    }
+}
+
+#[derive(Clone)]
+struct BatteryState {
+    state_of_charge: f64,
+    active_power: f64,
+    reactive_power: f64,
+}
+
+impl Display for BatteryState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:.1}%, {:.1}W, {:.1}VAR",
+            self.state_of_charge, self.active_power, self.reactive_power
+        )
+    }
+}
+
+#[derive(Clone)]
+struct PowerMeterState {
+    active_power: f64,
+    reactive_power: f64,
+    voltage: f64,
+}
+
+impl Display for PowerMeterState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:.1}W, {:.1}VAR, {:.1}V",
+            self.active_power, self.reactive_power, self.voltage
+        )
+    }
+}
+
+#[derive(Clone)]
+struct PlantState {
+    solar: SolarState,
+    battery: BatteryState,
+    power_meter: PowerMeterState,
+}
+
+impl Display for PlantState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Solar: {}, Battery: {}, Power Meter: {}",
+            self.solar, self.battery, self.power_meter
+        )
+    }
+}
+
+impl HasSlice<SolarState> for PlantState {
+    fn slice(&self) -> &SolarState {
+        &self.solar
+    }
+
+    fn set_slice(mut self, slice: SolarState) -> Self {
+        self.solar = slice;
+        self
+    }
+}
+
+impl HasSlice<BatteryState> for PlantState {
+    fn slice(&self) -> &BatteryState {
+        &self.battery
+    }
+
+    fn set_slice(mut self, slice: BatteryState) -> Self {
+        self.battery = slice;
+        self
+    }
+}
+
+impl HasSlice<PowerMeterState> for PlantState {
+    fn slice(&self) -> &PowerMeterState {
+        &self.power_meter
+    }
+
+    fn set_slice(mut self, slice: PowerMeterState) -> Self {
+        self.power_meter = slice;
+        self
+    }
+}
+
+#[derive(Clone)]
+enum Event {
+    SolarUpdate {
+        active_power: f64,
+        reactive_power: f64,
+        voltage: f64,
+    },
+    BatteryUpdate {
+        state_of_charge: f64,
+        active_power: f64,
+        reactive_power: f64,
+    },
+    PowerMeterUpdate {
+        active_power: f64,
+        reactive_power: f64,
+        voltage: f64,
+    },
+    // Triggered when the battery state of charge falls below a certain threshold
+    BatteryStateOfChargeLow,
+    // Command to control the battery, e.g., to reduce active power output
+    BatteryCommand {
+        active_power: f64,
+        reactive_power: f64,
+    },
+}
+
+impl Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::SolarUpdate {
+                active_power,
+                reactive_power,
+                voltage,
+            } => {
+                write!(
+                    f,
+                    "SolarUpdate: {:.1}W, {:.1}VAR, {:.1}V",
+                    active_power, reactive_power, voltage
+                )
+            }
+            Event::BatteryUpdate {
+                state_of_charge,
+                active_power,
+                reactive_power,
+            } => {
+                write!(
+                    f,
+                    "BatteryUpdate: {:.1}%, {:.1}W, {:.1}VAR",
+                    state_of_charge, active_power, reactive_power
+                )
+            }
+            Event::PowerMeterUpdate {
+                active_power,
+                reactive_power,
+                voltage,
+            } => {
+                write!(
+                    f,
+                    "PowerMeterUpdate: {:.1}W, {:.1}VAR, {:.1}V",
+                    active_power, reactive_power, voltage
+                )
+            }
+            Event::BatteryStateOfChargeLow => write!(f, "BatteryStateOfChargeLow"),
+            Event::BatteryCommand {
+                active_power,
+                reactive_power,
+            } => {
+                write!(
+                    f,
+                    "BatteryCommand: {:.1}W, {:.1}VAR",
+                    active_power, reactive_power
+                )
+            }
+        }
+    }
+}
+
+struct LoggingMiddleware;
+
+impl Middleware<PlantState, Event> for LoggingMiddleware {
+    fn wrap(self: Box<Self>, mut next: Next<PlantState, Event>) -> Next<PlantState, Event> {
+        Box::new(move |state, event| {
+            println!("Event received: {}", event);
+            println!("Current state: {}", state);
+            let side_events = next(state, event);
+            println!("New state: {}", state);
+            side_events
+        })
+    }
+}
+
+struct BatteryControlMiddleware;
+
+impl Middleware<PlantState, Event> for BatteryControlMiddleware {
+    fn wrap(self: Box<Self>, mut next: Next<PlantState, Event>) -> Next<PlantState, Event> {
+        Box::new(move |state, event| {
+            if let Event::BatteryStateOfChargeLow = event {
+                println!("Battery state of charge is low. Activating battery control.");
+                let command = Event::BatteryCommand {
+                    active_power: 0.0,
+                    reactive_power: 0.0,
+                };
+                println!("Issuing command: {} to reduce battery output.", command);
+                let mut side_events = next(state, event).unwrap_or_default();
+                side_events.push(command);
+                Some(side_events)
+            } else {
+                next(state, event)
+            }
+        })
+    }
+}
+
+struct SolarReducer;
+
+impl SliceReducer for SolarReducer {
+    type Event = Event;
+    type Slice = SolarState;
+
+    fn reduce(
+        &self,
+        state: &SolarState,
+        event: &Self::Event,
+    ) -> ReducerOutput<SolarState, Self::Event> {
+        match event {
+            Event::SolarUpdate {
+                active_power,
+                reactive_power,
+                voltage,
+            } => ReducerOutput {
+                state: SolarState {
+                    active_power: *active_power,
+                    reactive_power: *reactive_power,
+                    voltage: *voltage,
+                },
+                side_events: None,
+            },
+            _ => ReducerOutput {
+                state: state.clone(),
+                side_events: None,
+            },
+        }
+    }
+}
+
+struct BatteryReducer;
+
+impl SliceReducer for BatteryReducer {
+    type Event = Event;
+    type Slice = BatteryState;
+
+    fn reduce(
+        &self,
+        state: &BatteryState,
+        event: &Self::Event,
+    ) -> ReducerOutput<BatteryState, Self::Event> {
+        match event {
+            Event::BatteryUpdate {
+                state_of_charge,
+                active_power,
+                reactive_power,
+            } => {
+                let new_state = BatteryState {
+                    state_of_charge: *state_of_charge,
+                    active_power: *active_power,
+                    reactive_power: *reactive_power,
+                };
+
+                let mut side_events = None;
+                if new_state.state_of_charge < 20.0 {
+                    side_events = Some(vec![Event::BatteryStateOfChargeLow]);
+                }
+                ReducerOutput {
+                    state: new_state,
+                    side_events,
+                }
+            }
+            Event::BatteryCommand {
+                active_power,
+                reactive_power,
+            } => ReducerOutput {
+                state: BatteryState {
+                    state_of_charge: state.state_of_charge,
+                    active_power: *active_power,
+                    reactive_power: *reactive_power,
+                },
+                side_events: None,
+            },
+            _ => ReducerOutput {
+                state: state.clone(),
+                side_events: None,
+            },
+        }
+    }
+}
+
+struct PowerMeterReducer;
+
+impl SliceReducer for PowerMeterReducer {
+    type Event = Event;
+    type Slice = PowerMeterState;
+    fn reduce(
+        &self,
+        state: &PowerMeterState,
+        event: &Self::Event,
+    ) -> ReducerOutput<PowerMeterState, Self::Event> {
+        match event {
+            Event::PowerMeterUpdate {
+                active_power,
+                reactive_power,
+                voltage,
+            } => ReducerOutput {
+                state: PowerMeterState {
+                    active_power: *active_power,
+                    reactive_power: *reactive_power,
+                    voltage: *voltage,
+                },
+                side_events: None,
+            },
+            _ => ReducerOutput {
+                state: state.clone(),
+                side_events: None,
+            },
+        }
+    }
+}
+
+fn make_root_reducer() -> impl Reducer<PlantState, Event = Event> {
+    (SolarReducer, BatteryReducer, PowerMeterReducer)
+}
+
+fn main() {
+    println!("EMS Sequential Example");
+
+    let initial_state = PlantState {
+        solar: SolarState {
+            active_power: 0.0,
+            reactive_power: 0.0,
+            voltage: 0.0,
+        },
+        battery: BatteryState {
+            state_of_charge: 100.0,
+            active_power: 0.0,
+            reactive_power: 0.0,
+        },
+        power_meter: PowerMeterState {
+            active_power: 0.0,
+            reactive_power: 0.0,
+            voltage: 0.0,
+        },
+    };
+    let root_reducer = make_root_reducer();
+    let middlewares: Vec<Box<dyn Middleware<PlantState, Event>>> = vec![
+        Box::new(LoggingMiddleware),
+        Box::new(BatteryControlMiddleware),
+    ];
+    let mut store = Store::new(initial_state, root_reducer, middlewares, 10);
+
+    store
+        .dispatch(Event::SolarUpdate {
+            active_power: 100.0,
+            reactive_power: 50.0,
+            voltage: 240.0,
+        })
+        .expect("dispatch failed");
+    store
+        .dispatch(Event::BatteryUpdate {
+            state_of_charge: 10.0,
+            active_power: 50.0,
+            reactive_power: 25.0,
+        })
+        .expect("dispatch failed");
+    store
+        .dispatch(Event::PowerMeterUpdate {
+            active_power: 150.0,
+            reactive_power: 75.0,
+            voltage: 240.0,
+        })
+        .expect("dispatch failed");
+
+    println!("Final state: {}", store.state());
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,7 +10,12 @@ use std::collections::VecDeque;
 #[derive(Debug, PartialEq)]
 pub enum DispatchError {
     /// Side-event recursion exceeded `max_depth`.
-    MaxDepthExceeded { depth: usize, max: usize },
+    MaxDepthExceeded {
+        /// Depth at which the offending event was produced (0 = original dispatch).
+        depth: usize,
+        /// The configured `max_depth` limit passed to [`Store::new`].
+        max: usize,
+    },
 }
 
 struct PendingEvent<E> {
@@ -34,7 +39,7 @@ pub struct Store<S, E> {
 
 impl<S, E> Store<S, E> {
     /// Builds a store from an initial state, a reducer, and an ordered list
-    /// of middlewares (see [`crate::middleware`] for the composition order).
+    /// of middlewares (see [`Middleware`] for the composition order).
     ///
     /// `max_depth` bounds the side-event re-dispatch depth (original dispatch
     /// is depth 0). An event at depth `max_depth` may run but cannot emit


### PR DESCRIPTION
## Summary

Completes the MVP documentation: a realistic multi-slice example, an enriched README, and rustdoc fixes. The library is now understandable and demonstrable end-to-end.

## Related Issue

Closes #7

## Changes

**Example** — `examples/ems_sequential.rs`
- A mini Energy Management System with 3 isolated slices (solar, battery, power meter)
- Typed events, sequential slice reducers composed via tuple syntax
- Two middlewares: a logger and a battery controller
- Side events emitted from **both** a reducer (low-SOC detection) and a middleware (control command), showing reducers and middlewares cooperating through the event queue
- `//!` header explaining the EMS domain for non-EMS readers, with expected output

**README**
- Quick start (a minimal counter, verified compilable)
- `classDiagram` of the public API replacing the old ASCII glossary
- Comparison table with redux-rs (terminology, slice isolation, reducer ownership, side events, async/concurrency, middleware registration, selectors)
- Pointer to the rustdoc instead of an inline API dump
- Prose unwrapped (no hard line-wrapping)

**rustdoc** — `src/store.rs`
- Fix broken intra-doc link in `Store::new` (pointed at the private `middleware` module)
- Document the `DispatchError::MaxDepthExceeded` fields

**Process rules** — `.claude/`
- `learning-mode`: example programs are implementation code (Claude challenges/reviews, does not design or write them on its own)
- `validate-design`: separate design-level feedback from implementation-level feedback

## Notes for Reviewers

- Two design tradeoffs surfaced during this work and were filed rather than acted on:
  - **#23** (created): async middleware support — middlewares can't currently spawn background work that re-dispatches into the store
  - **Note on #9**: the per-dispatch state clone (ruxe borrows `&S`, redux-rs moves `State` in); to be measured during benchmarking before any API change
- `cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test` (16), and `cargo doc -D warnings` all pass.