### PR TITLE
docs: mark MVP documentation as done in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ In short: redux-rs is async-first and ships more batteries (selectors, Tokio int
 | 1       | [SliceReducer][i4]                 | done    |
 | 1       | [Sequential RootReducer][i5]       | done    |
 | 1       | [Middleware][i6]                   | done    |
-| 1       | [Documentation & EMS example][i7]  | planned |
+| 1       | [Documentation & EMS example][i7]  | done    |
 | 2       | [Parallel RootReducer (rayon)][i8] | planned |
 | 2       | [Benchmarks][i9]                   | planned |
 


### PR DESCRIPTION
## Summary

Follow-up to #24: the roadmap still listed the MVP documentation & EMS example as `planned`. It's merged, so the whole Phase 1 (MVP) is now `done`.

## Changes

- Roadmap: `Documentation & EMS example` → `done`

## Notes

Trivial one-line fix that should have been part of #24.