### PR TITLE
feat: state-change subscription via watch stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Existing Rust Redux implementations (redux-rs, rust_redux) lack key features: Ro
 ```rust
 use ruxe::{Reducer, ReducerOutput, Store};
 
-// 1. Define your state. It must be `Clone`.
+// 1. Define your state. (`Clone` is only needed for parallel reducers
+//    or state subscriptions, not for a synchronous store like this.)
 #[derive(Clone)]
 struct Counter {
     value: i32,
@@ -169,8 +170,6 @@ flowchart TB
 
     State[State struct] -.must impl HasSlice&lt;T&gt; per slice.-> SR1
     ParRR[ParallelRootReducer only] -.requires.-> SS[StateSlices on State]
-
-    style Wrapper fill:#f9f,stroke:#333,stroke-width:2px
 ```
 
 Slice reducers compose into a root reducer via either [`SequentialRootReducer<T>`] (applies them in order, threading state through `set_slice`) or [`ParallelRootReducer<L, E, Indices>`] (applies them on Rayon workers, with compile-time disjointness verification). `Next<S, E>` is the dispatch-chain closure each middleware wraps, and `DispatchError` is returned when side-event recursion exceeds the configured depth.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Why ruxe?
 
-Existing Rust Redux implementations (redux-rs, rust_redux) lack key features: RootReducer, SliceReducer, and parallel execution. ruxe fills that gap by leveraging Rust's ownership model — not as a constraint, but as a feature — to guarantee data-race-free parallel reducers at compile time.
+Existing Rust Redux implementations (redux-rs, rust_redux) lack key features: RootReducer, SliceReducer, and parallel execution. ruxe fills that gap by using Rust's ownership model to guarantee data-race-free parallel reducers at compile time.
 
 ## Quick start
 
@@ -242,7 +242,7 @@ See [the project epic](https://github.com/corentin-core/ruxe/issues/1) for the f
 
 ruxe is built as a Rust learning project. The code is written by hand — Claude Code is configured in **learning mode**: it reviews, challenges, and explains, but does not write implementation code.
 
-The Claude configuration showcasing this workflow is tracked in the repo:
+The Claude configuration for this workflow is tracked in the repo:
 
 - [`CLAUDE.md`](CLAUDE.md) — project instructions and learning workflow
 - [`.claude/rules/learning-mode.md`](.claude/rules/learning-mode.md) — behavioral constraints (what Claude does and doesn't do)

--- a/README.md
+++ b/README.md
@@ -121,10 +121,29 @@ let store = actor_loop.run().await.expect("clean shutdown");
 
 The loop is the store's **sole owner**: dispatch stays lock-free and serialized however many producers feed it, and the core stays runtime-agnostic.
 
+### Reacting to state changes
+
+`init_actor_loop_with_subscription` adds a read side. Alongside the handle and loop it returns a `Stream<Item = Arc<S>>` of state snapshots: it replays the current state on subscribe, yields the settled state after each dispatch (intermediate values coalesced), and ends when the loop stops.
+
+```rust
+use futures::StreamExt;
+use ruxe::init_actor_loop_with_subscription;
+
+let (handle, actor_loop, mut states) = init_actor_loop_with_subscription(store, 32);
+
+// React from outside the loop: an outbound sink, a controller, ...
+tokio::spawn(async move {
+    while let Some(state) = states.next().await {
+        println!("state changed: {state:?}");
+    }
+});
+```
+
+It stays opt-in: [`init_actor_loop`] and the synchronous store are unaffected, and a snapshot is cloned only while a subscriber is alive (`S: Clone` is required only on this path).
+
 Planned companions:
 
 - **[tokio adapter][i37]** — a reference executor behind a feature flag
-- **[state subscription][i35]** — react to state changes from outside the loop
 - **[event stream][i36]** — react to the dispatched events themselves (`action$`-style)
 
 Runnable demo: [`examples/async_dispatch.rs`](examples/async_dispatch.rs).
@@ -196,7 +215,7 @@ In short: redux-rs is async-first and ships more batteries (selectors, Tokio int
 | 2       | [Benchmarks][i9]                   | planned |
 | 3       | [Async dispatch (actor loop)][i23] | done    |
 | 3       | [tokio adapter][i37]               | planned |
-| 3       | [State-change subscription][i35]   | planned |
+| 3       | [State-change subscription][i35]   | done    |
 | 3       | [Event-stream subscription][i36]   | planned |
 
 [i2]: https://github.com/corentin-core/ruxe/issues/2

--- a/examples/async_dispatch.rs
+++ b/examples/async_dispatch.rs
@@ -1,33 +1,84 @@
-//! Async event ingestion — concurrent producers feeding one actor-driven store.
+//! Async event ingestion: concurrent producers feeding one actor-driven store,
+//! plus a controller reacting to state changes.
 //!
 //! Reuses the EMS domain from `common` (see `examples/ems.rs` for the domain
-//! walkthrough) and demonstrates the async dispatch primitive:
+//! walkthrough) and demonstrates the async dispatch and subscription primitives:
 //!
-//! - `init_actor_loop` wraps the `Store` in an actor loop — the sole owner
-//!   of the state
+//! - `init_actor_loop_with_subscription` wraps the `Store` in an actor loop
+//!   (the sole owner of the state) and returns a state `Stream`
 //! - Three tokio tasks dispatch device updates concurrently through cloned,
-//!   `Send` `DispatchHandle`s; the loop serializes them into one ordered
-//!   stream of dispatches, lock-free
-//! - Shutdown is cooperative: producers finish and drop their handles, the
-//!   loop drains the channel, then `run()` returns the final `Store`
+//!   `Send` `DispatchHandle`s; the loop serializes them lock-free
+//! - A `SolarController` task reacts to state changes from the `Stream` and
+//!   dispatches commands back through its own handle, closing the
+//!   react-to-state loop
+//! - Shutdown is cooperative: a `Termination` event flips a state flag the
+//!   controller observes, so it stops and drops its handle. Once every handle
+//!   is gone, the loop drains the channel and `run()` returns the final `Store`
 //!
 //! Caveat: the demo reducers block 50ms per event (`REDUCER_WORK_SIMULATION`),
 //! and that work runs *inside the actor loop*, on the tokio task awaiting
-//! `run()` — acceptable for a demo, an antipattern in real async code.
+//! `run()`. Fine for a demo, an antipattern in real async code.
 //!
 //! Run with: `cargo run --example async_dispatch`
 
 mod common;
 
-use ruxe::{ParallelRootReducer, Store, init_actor_loop};
-
 use crate::common::*;
+use futures::Stream;
+use futures::StreamExt;
+use ruxe::{DispatchHandle, ParallelRootReducer, Store, init_actor_loop_with_subscription};
+use std::sync::Arc;
+
+struct SolarController<Listener: Stream<Item = Arc<PlantState>> + Unpin> {
+    dispatch_handle: DispatchHandle<Event>,
+    state_listener: Listener,
+}
+
+impl<Listener> SolarController<Listener>
+where
+    Listener: Stream<Item = Arc<PlantState>> + Unpin,
+{
+    async fn run(mut self) {
+        while let Some(state) = self.state_listener.next().await {
+            if state.system.termination_requested {
+                println!("Termination requested. Stopping SolarController.");
+                break;
+            }
+
+            if state.battery.active_power == 0.0 && state.solar.active_power > 0.0 {
+                println!("Battery stopped, stopping solar power generation.");
+                if self
+                    .dispatch_handle
+                    .dispatch(Event::SolarUpdate {
+                        active_power: 0.0,
+                        reactive_power: 0.0,
+                        voltage: 0.0,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {
-    let root_reducer = ParallelRootReducer::new((SolarReducer, BatteryReducer, PowerMeterReducer));
+    let root_reducer = ParallelRootReducer::new((
+        SystemReducer,
+        SolarReducer,
+        BatteryReducer,
+        PowerMeterReducer,
+    ));
     let store = Store::new(initial_state(), root_reducer, middlewares(), 10);
-    let (handle, actor_loop) = init_actor_loop(store, 10);
+    let (handle, actor_loop, listener) = init_actor_loop_with_subscription(store, 10);
+
+    let solar_controller = SolarController {
+        dispatch_handle: handle.clone(),
+        state_listener: listener,
+    };
 
     let mut solar_handle = handle.clone();
     // Create tokio tasks sending device state updates periodically to the store. The store will process these updates concurrently.
@@ -75,9 +126,24 @@ async fn main() {
         }
     });
 
+    let mut termination_handle = handle.clone();
+    let termination_task = tokio::spawn(async move {
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        termination_handle
+            .dispatch(Event::Termination {})
+            .await
+            .expect("Termination signal should be sent");
+    });
+
     drop(handle); // Close the sender to stop the actor loop after processing the events
-    let (_, _, _, result) =
-        tokio::join!(solar_task, power_meter_task, battery_task, actor_loop.run());
+    let (_, _, _, _, _, result) = tokio::join!(
+        termination_task,
+        solar_controller.run(),
+        solar_task,
+        power_meter_task,
+        battery_task,
+        actor_loop.run()
+    );
     let store = result.expect("Actor loop should complete successfully");
     println!("Final state: {}", store.state());
 }

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::{fmt::Display, thread, time::Duration};
 
 use ruxe::{HasSlice, Middleware, Next, ReducerOutput, SliceReducer, StateSlices};
@@ -9,9 +11,9 @@ const REDUCER_WORK_SIMULATION: Duration = Duration::from_millis(50);
 
 #[derive(Clone)]
 pub struct SolarState {
-    active_power: f64,
-    reactive_power: f64,
-    voltage: f64,
+    pub active_power: f64,
+    pub reactive_power: f64,
+    pub voltage: f64,
 }
 
 impl Display for SolarState {
@@ -26,9 +28,9 @@ impl Display for SolarState {
 
 #[derive(Clone)]
 pub struct BatteryState {
-    state_of_charge: f64,
-    active_power: f64,
-    reactive_power: f64,
+    pub state_of_charge: f64,
+    pub active_power: f64,
+    pub reactive_power: f64,
 }
 
 impl Display for BatteryState {
@@ -43,9 +45,9 @@ impl Display for BatteryState {
 
 #[derive(Clone)]
 pub struct PowerMeterState {
-    active_power: f64,
-    reactive_power: f64,
-    voltage: f64,
+    pub active_power: f64,
+    pub reactive_power: f64,
+    pub voltage: f64,
 }
 
 impl Display for PowerMeterState {
@@ -59,18 +61,30 @@ impl Display for PowerMeterState {
 }
 
 #[derive(Clone)]
+pub struct System {
+    pub termination_requested: bool,
+}
+
+impl Display for System {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Termination requested: {}", self.termination_requested)
+    }
+}
+
+#[derive(Clone)]
 pub struct PlantState {
-    solar: SolarState,
-    battery: BatteryState,
-    power_meter: PowerMeterState,
+    pub solar: SolarState,
+    pub battery: BatteryState,
+    pub power_meter: PowerMeterState,
+    pub system: System,
 }
 
 impl Display for PlantState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Solar: {}, Battery: {}, Power Meter: {}",
-            self.solar, self.battery, self.power_meter
+            "Solar: {}, Battery: {}, Power Meter: {}, System: {}",
+            self.solar, self.battery, self.power_meter, self.system
         )
     }
 }
@@ -108,8 +122,19 @@ impl HasSlice<PowerMeterState> for PlantState {
     }
 }
 
+impl HasSlice<System> for PlantState {
+    fn slice(&self) -> &System {
+        &self.system
+    }
+
+    fn set_slice(mut self, slice: System) -> Self {
+        self.system = slice;
+        self
+    }
+}
+
 impl StateSlices for PlantState {
-    type Slices = ruxe::HList!(SolarState, BatteryState, PowerMeterState);
+    type Slices = ruxe::HList!(SolarState, BatteryState, PowerMeterState, System);
 }
 
 #[derive(Clone, Debug)]
@@ -134,6 +159,7 @@ pub enum Event {
         active_power: f64,
         reactive_power: f64,
     },
+    Termination {},
 }
 
 impl Display for Event {
@@ -175,6 +201,7 @@ impl Display for Event {
                 "BatteryCommand: {:.1}W, {:.1}VAR",
                 active_power, reactive_power
             ),
+            Event::Termination {} => write!(f, "Termination"),
         }
     }
 }
@@ -333,6 +360,29 @@ impl SliceReducer for PowerMeterReducer {
     }
 }
 
+pub struct SystemReducer;
+
+impl SliceReducer for SystemReducer {
+    type Event = Event;
+    type Slice = System;
+
+    fn reduce(&self, state: &System, event: &Self::Event) -> ReducerOutput<System, Self::Event> {
+        thread::sleep(REDUCER_WORK_SIMULATION);
+        match event {
+            Event::Termination {} => ReducerOutput {
+                state: System {
+                    termination_requested: true,
+                },
+                side_events: None,
+            },
+            _ => ReducerOutput {
+                state: state.clone(),
+                side_events: None,
+            },
+        }
+    }
+}
+
 pub fn initial_state() -> PlantState {
     PlantState {
         solar: SolarState {
@@ -349,6 +399,9 @@ pub fn initial_state() -> PlantState {
             active_power: 0.0,
             reactive_power: 0.0,
             voltage: 0.0,
+        },
+        system: System {
+            termination_requested: false,
         },
     }
 }

--- a/examples/ems.rs
+++ b/examples/ems.rs
@@ -89,6 +89,7 @@ fn main() {
         SolarReducer,
         BatteryReducer,
         PowerMeterReducer,
+        SystemReducer,
     )));
 
     println!("\n=== EMS Example — Parallel ===\n");
@@ -96,6 +97,7 @@ fn main() {
         SolarReducer,
         BatteryReducer,
         PowerMeterReducer,
+        SystemReducer,
     )));
 
     println!("\n=== Timing comparison ===");

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -4,12 +4,14 @@
 //! [`ActorLoop`] that owns the store and serializes every dispatch. The send
 //! error types live here too.
 
+use crate::watch;
 use crate::{DispatchError, Store};
-use futures::StreamExt;
 use futures::channel::mpsc::{Receiver, Sender};
 use futures::future::poll_fn;
+use futures::{Stream, StreamExt};
 use std::error::Error;
 use std::fmt::{Debug, Display};
+use std::sync::Arc;
 
 /// The bounded channel had no spare capacity — transient, a later attempt
 /// may succeed. Carries the rejected event ([`Self::into_inner`]).
@@ -147,16 +149,64 @@ impl<E> DispatchHandle<E> {
     }
 }
 
-/// Sole owner of a [`Store`]: drains the channel and dispatches each event
-/// serially — no locks, no other task ever touches the state.
-///
-/// Created by [`init_actor_loop`]; driven by [`run`](ActorLoop::run).
-pub struct ActorLoop<S, E> {
-    store: Store<S, E>,
-    receiver: Receiver<E>,
+///  Sealed trait pattern to prevent downstream crates to implement Publish trait
+mod sealed {
+    pub trait Sealed {}
 }
 
-impl<S, E> ActorLoop<S, E> {
+/// State-publication policy for [`ActorLoop`]. Sealed, so only [`NoPublish`]
+/// (the default no-op) and [`WatchPublish`] implement it.
+#[doc(hidden)]
+pub trait Publish<S>: sealed::Sealed {
+    fn publish(&self, state: &S);
+
+    fn has_receivers(&self) -> bool;
+}
+
+#[doc(hidden)]
+pub struct NoPublish {
+    // This is a private field to prevent instantiation outside of this module
+    _private: (),
+}
+impl<S> Publish<S> for NoPublish {
+    fn publish(&self, _: &S) {}
+
+    fn has_receivers(&self) -> bool {
+        false
+    }
+}
+
+impl sealed::Sealed for NoPublish {}
+
+#[doc(hidden)]
+pub struct WatchPublish<S> {
+    publisher: watch::Sender<Arc<S>>,
+}
+
+impl<S> sealed::Sealed for WatchPublish<S> {}
+
+impl<S: Clone> Publish<S> for WatchPublish<S> {
+    fn publish(&self, state: &S) {
+        self.publisher.send(Arc::new(state.clone()));
+    }
+
+    fn has_receivers(&self) -> bool {
+        self.publisher.has_receivers()
+    }
+}
+
+/// Sole owner of a [`Store`]: drains the channel and dispatches each event
+/// serially, lock-free, so no other task ever touches the state.
+///
+/// Created by [`init_actor_loop`]; driven by [`run`](ActorLoop::run). The `P`
+/// parameter selects the publication policy, [`NoPublish`] by default.
+pub struct ActorLoop<S, E, P: Publish<S> = NoPublish> {
+    store: Store<S, E>,
+    receiver: Receiver<E>,
+    publisher: P,
+}
+
+impl<S, E, P: Publish<S>> ActorLoop<S, E, P> {
     /// Drives the store until every [`DispatchHandle`] is dropped, then
     /// returns it.
     ///
@@ -169,7 +219,10 @@ impl<S, E> ActorLoop<S, E> {
     /// `tokio::spawn`ed.
     pub async fn run(mut self) -> Result<Store<S, E>, DispatchError> {
         while let Some(event) = self.receiver.next().await {
-            self.store.dispatch(event)?
+            self.store.dispatch(event)?;
+            if self.publisher.has_receivers() {
+                self.publisher.publish(self.store.state());
+            }
         }
         Ok(self.store)
     }
@@ -203,8 +256,47 @@ pub fn init_actor_loop<S, E>(
 ) -> (DispatchHandle<E>, ActorLoop<S, E>) {
     let (sender, receiver) = futures::channel::mpsc::channel(max_event_buffer);
     let handle = DispatchHandle { sender };
-    let actor_loop = ActorLoop { store, receiver };
+    let actor_loop = ActorLoop {
+        store,
+        receiver,
+        publisher: NoPublish { _private: () },
+    };
     (handle, actor_loop)
+}
+
+type PublishingActorLoop<S, E> = ActorLoop<S, E, WatchPublish<S>>;
+
+/// Like [`init_actor_loop`], with a state-change subscription added.
+///
+/// Also returns a `Stream<Item = Arc<S>>` yielding a state snapshot after each
+/// dispatch, once the side-event cascade has settled. The stream replays the
+/// current state on subscribe, coalesces intermediate values, and ends when
+/// the loop stops.
+///
+/// `S: Clone` is required only here; [`init_actor_loop`] and the synchronous
+/// store stay unaffected. A snapshot is cloned only while a subscriber is
+/// alive, so dropping the listener lets the loop skip the clone.
+#[must_use = "dropping the returned loop or listener discards the subscription; drive the loop with run()"]
+pub fn init_actor_loop_with_subscription<S, E>(
+    store: Store<S, E>,
+    max_event_buffer: usize,
+) -> (
+    DispatchHandle<E>,
+    PublishingActorLoop<S, E>,
+    impl Stream<Item = Arc<S>> + Clone,
+)
+where
+    S: Clone,
+{
+    let (sender, receiver) = futures::channel::mpsc::channel(max_event_buffer);
+    let handle = DispatchHandle { sender };
+    let (publisher, listener) = watch::watch(Arc::new(store.state().clone()));
+    let actor_loop = ActorLoop {
+        store,
+        receiver,
+        publisher: WatchPublish { publisher },
+    };
+    (handle, actor_loop, listener)
 }
 
 #[cfg(test)]
@@ -342,7 +434,7 @@ mod tests {
 
     mod actor_loop {
         use crate::{DispatchError, Reducer, ReducerOutput, Store, init_actor_loop};
-        use futures::executor::block_on;
+        use futures::{StreamExt, executor::block_on, join};
 
         use Event::*;
 
@@ -442,6 +534,63 @@ mod tests {
                 Ok(_) => panic!("Actor loop should have failed due to max recursion depth"),
                 Err(err) => assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 10, max: 10 }),
             }
+        }
+
+        #[test]
+        fn actor_loop_with_subscription() {
+            let store = make_store();
+            let (mut handle, actor_loop, mut listener) =
+                crate::actor::init_actor_loop_with_subscription(store, 10);
+            let (_, result) = block_on(async {
+                join!(
+                    async {
+                        assert_eq!(
+                            listener
+                                .next()
+                                .await
+                                .expect("A state should be received")
+                                .name,
+                            ""
+                        );
+                        handle
+                            .try_dispatch(Append { value: 'a' })
+                            .expect("Dispatch should succeed");
+                        assert_eq!(
+                            listener
+                                .next()
+                                .await
+                                .expect("A state should be received")
+                                .name,
+                            "a"
+                        );
+                        handle
+                            .try_dispatch(Append { value: 'b' })
+                            .expect("Dispatch should succeed");
+                        assert_eq!(
+                            listener
+                                .next()
+                                .await
+                                .expect("A state should be received")
+                                .name,
+                            "ab"
+                        );
+                        handle
+                            .try_dispatch(Append { value: 'c' })
+                            .expect("Dispatch should succeed");
+                        assert_eq!(
+                            listener
+                                .next()
+                                .await
+                                .expect("A state should be received")
+                                .name,
+                            "abc"
+                        );
+                        drop(handle);
+                    },
+                    actor_loop.run()
+                )
+            });
+            result.expect("Actor loop should run successfully");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,9 @@ mod reducer;
 mod sequential_root_reducer;
 mod state;
 mod store;
+mod watch;
 
-pub use actor::{ActorLoop, DispatchHandle, init_actor_loop};
+pub use actor::{ActorLoop, DispatchHandle, init_actor_loop, init_actor_loop_with_subscription};
 #[doc(hidden)]
 pub use hlist::{HCons, HList, HNil, IntoHList};
 #[doc(hidden)]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,348 @@
+//! A `watch`-style broadcast of the latest value, hand-recoded on `futures`
+//! so the core keeps no runtime dependency.
+//!
+//! [`watch`] pairs a [`Sender`] with a [`Receiver`].
+//!
+//! Each `send` overwrites a single shared slot and bumps a version, so a
+//! receiver observes the latest value; intermediate values are coalesced.
+//!
+//! A [`Receiver`] is a `Stream<Item = T>`: it yields the current value on first
+//! poll, then one item per change, and ends with `None` once the [`Sender`] is
+//! dropped.
+
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    task::{Context, Poll},
+};
+
+use futures::{Stream, task::Waker};
+
+struct WakerRegistry {
+    wakers: HashMap<u64, Waker>,
+    next_waker_id: u64,
+}
+
+impl WakerRegistry {
+    fn new() -> Self {
+        Self {
+            wakers: HashMap::new(),
+            next_waker_id: 0,
+        }
+    }
+
+    fn reserve_id(&mut self) -> u64 {
+        let id = self.next_waker_id;
+        self.next_waker_id += 1;
+        id
+    }
+
+    fn register(&mut self, reg_id: u64, waker: &Waker) {
+        self.wakers.insert(reg_id, waker.clone());
+    }
+
+    fn unregister(&mut self, id: u64) {
+        self.wakers.remove(&id);
+    }
+
+    fn collect_wakers(&self) -> Vec<Waker> {
+        self.wakers.values().cloned().collect()
+    }
+}
+
+pub(crate) struct Shared<T> {
+    value: Mutex<T>,
+    version: AtomicU64,
+    wakers: Mutex<WakerRegistry>,
+    closed: AtomicBool,
+}
+
+impl<T> Shared<T> {
+    fn new(value: T) -> Self {
+        Self {
+            value: Mutex::new(value),
+            version: AtomicU64::new(1), // Start at 1 so that initial value is considered changed
+            wakers: Mutex::new(WakerRegistry::new()),
+            closed: AtomicBool::new(false),
+        }
+    }
+
+    fn value(&self) -> MutexGuard<'_, T> {
+        self.value.lock().expect("Lock should not be poisoned")
+    }
+
+    fn wake_registry(&self) -> MutexGuard<'_, WakerRegistry> {
+        self.wakers.lock().expect("Lock should not be poisoned")
+    }
+
+    fn register(&self, waker_id: u64, waker: &Waker) {
+        self.wake_registry().register(waker_id, waker);
+    }
+
+    fn unregister(&self, waker_id: u64) {
+        self.wake_registry().unregister(waker_id);
+    }
+
+    fn reserve_id(&self) -> u64 {
+        self.wake_registry().reserve_id()
+    }
+
+    fn version(&self) -> u64 {
+        self.version.load(Ordering::SeqCst)
+    }
+
+    fn wake_receivers(&self) {
+        let wakers = self.wake_registry().collect_wakers();
+        for waker in wakers {
+            waker.wake_by_ref();
+        }
+    }
+}
+
+/// Receiving half: a `Stream<Item = T>` over the latest value. Cloning yields
+/// an independent subscriber that replays the current value on its next poll.
+pub(crate) struct Receiver<T> {
+    shared: Arc<Shared<T>>,
+    last_seen_version: u64,
+    waker_id: Option<u64>,
+}
+
+impl<T> Receiver<T> {
+    pub(crate) fn new(shared: Arc<Shared<T>>) -> Self {
+        Self {
+            shared,
+            last_seen_version: 0,
+            waker_id: None,
+        }
+    }
+}
+
+impl<T: Clone> Stream for Receiver<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.waker_id.is_none() {
+            let waker_id = this.shared.reserve_id();
+            this.waker_id = Some(waker_id);
+        }
+
+        let waker_id = this.waker_id.expect("waker id should be set");
+        // Register the waker before reading version/closed. The reverse order
+        // loses a wakeup if a send lands in between.
+        this.shared.register(waker_id, cx.waker());
+
+        let guard = this.shared.value();
+        let current_version = this.shared.version();
+        if current_version != this.last_seen_version {
+            this.last_seen_version = current_version;
+            Poll::Ready(Some(guard.clone()))
+        } else if this.shared.closed.load(Ordering::SeqCst) {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl<T> Clone for Receiver<T> {
+    fn clone(&self) -> Self {
+        Self {
+            shared: Arc::clone(&self.shared),
+            last_seen_version: 0, // Start fresh for the new receiver to get the current value
+            waker_id: None,
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        if let Some(waker_id) = self.waker_id.take() {
+            self.shared.unregister(waker_id);
+        }
+    }
+}
+
+/// Sending half of a [`watch`] channel. Single producer, not `Clone`.
+pub(crate) struct Sender<T> {
+    shared: Arc<Shared<T>>,
+}
+
+impl<T> Sender<T> {
+    /// Overwrites the latest value and wakes every receiver. A slow receiver
+    /// observes only the most recent value.
+    pub(crate) fn send(&self, value: T) {
+        {
+            let mut shared_value = self.shared.value();
+            *shared_value = value;
+            self.shared.version.fetch_add(1, Ordering::SeqCst);
+        }
+        self.shared.wake_receivers();
+    }
+
+    /// Whether at least one [`Receiver`] is still alive, so a producer can
+    /// skip computing a value nobody would observe.
+    pub(crate) fn has_receivers(&self) -> bool {
+        Arc::strong_count(&self.shared) > 1
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        self.shared.closed.store(true, Ordering::SeqCst);
+        self.shared.wake_receivers();
+    }
+}
+
+/// Creates a [`Sender`]/[`Receiver`] pair seeded with `initial_value`. The
+/// initial value counts as the first version, so a fresh receiver yields it on
+/// first poll.
+pub(crate) fn watch<T>(initial_value: T) -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Shared::new(initial_value));
+    let sender = Sender {
+        shared: Arc::clone(&shared),
+    };
+    let receiver = Receiver::new(shared);
+    (sender, receiver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use futures::{executor::block_on, join};
+    use std::fmt::Debug;
+
+    fn assert_expected_received<T: PartialEq + Clone + Debug>(
+        mut receiver: Receiver<T>,
+        expected: T,
+    ) {
+        block_on(async {
+            assert_eq!(receiver.next().await, Some(expected));
+        });
+    }
+
+    #[test]
+    fn watch_initial_value() {
+        let (_sender, receiver) = watch(0);
+        assert_expected_received(receiver, 0);
+    }
+
+    #[test]
+    fn watch_changed() {
+        let (sender, receiver) = watch(0);
+
+        sender.send(1);
+        assert_expected_received(receiver, 1);
+    }
+
+    #[test]
+    fn has_receiver() {
+        let (sender, receiver) = watch(0);
+        assert!(sender.has_receivers());
+        drop(receiver);
+        assert!(!sender.has_receivers());
+    }
+
+    #[test]
+    fn watch_multiple_receivers() {
+        let (sender, mut receiver1) = watch(0);
+        let mut receiver2 = receiver1.clone();
+
+        block_on(async {
+            join!(
+                async {
+                    assert_eq!(receiver1.next().await, Some(0));
+                    assert_eq!(receiver1.next().await, Some(1));
+                },
+                async {
+                    assert_eq!(receiver2.next().await, Some(0));
+                    assert_eq!(receiver2.next().await, Some(1));
+                },
+                async {
+                    sender.send(1);
+                },
+            );
+        })
+    }
+
+    #[test]
+    fn value_coalescing() {
+        let (sender, receiver) = watch(0);
+
+        sender.send(1);
+        sender.send(2);
+        sender.send(3);
+
+        assert_expected_received(receiver, 3);
+    }
+
+    #[test]
+    fn wakes_parked_receiver() {
+        let (sender, mut receiver) = watch(0);
+        block_on(async {
+            join!(
+                async {
+                    assert_eq!(receiver.next().await, Some(0));
+                    assert_eq!(receiver.next().await, Some(1));
+                },
+                async {
+                    sender.send(1);
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn drop_sender_wakes_parked_receiver() {
+        let (sender, mut receiver) = watch(0);
+        block_on(async {
+            join!(
+                async {
+                    assert_eq!(receiver.next().await, Some(0));
+                    assert_eq!(receiver.next().await, None);
+                },
+                async {
+                    drop(sender);
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn drains_final_value_before_close() {
+        let (sender, mut receiver) = watch(0);
+        block_on(async {
+            join!(
+                async {
+                    assert_eq!(receiver.next().await, Some(0)); // Initial value
+                    // Receiver is parked, then sender sends a value and then drops itself
+                    // Receiver is awaken and should receive the new value before seeing None
+                    assert_eq!(receiver.next().await, Some(1));
+                    assert_eq!(receiver.next().await, None);
+                },
+                async {
+                    sender.send(1);
+                    drop(sender);
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn multithreaded() {
+        let (sender, mut receiver) = watch(0);
+        let sender_thread = std::thread::spawn(move || {
+            sender.send(1);
+        });
+        block_on(async {
+            assert_eq!(receiver.next().await, Some(0));
+            assert_eq!(receiver.next().await, Some(1));
+        });
+        sender_thread.join().unwrap();
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,11 +2,12 @@
 //! pipeline. Complements unit tests by validating the cross-component flow.
 
 use futures::executor::block_on;
-use futures::join;
+use futures::{StreamExt, join};
 use ruxe::{
     HasSlice, Middleware, Next, ParallelRootReducer, ReducerOutput, SequentialRootReducer,
-    SliceReducer, StateSlices, Store, init_actor_loop,
+    SliceReducer, StateSlices, Store, init_actor_loop, init_actor_loop_with_subscription,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug, PartialEq)]
 struct CountSlice {
@@ -110,7 +111,7 @@ fn initial_state() -> AppState {
 /// A middleware that records every event it observes — used to verify the
 /// dispatch chain flows through middleware as expected.
 struct Recorder {
-    log: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    log: Arc<Mutex<Vec<String>>>,
 }
 
 impl Middleware<AppState, Event> for Recorder {
@@ -163,7 +164,7 @@ fn parallel_root_reducer_via_store() {
 
 #[test]
 fn parallel_root_reducer_emits_side_events_through_store() {
-    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let log = Arc::new(Mutex::new(Vec::new()));
     let recorder = Recorder { log: log.clone() };
 
     let mut store = Store::new(
@@ -181,7 +182,7 @@ fn parallel_root_reducer_emits_side_events_through_store() {
 
 #[test]
 fn actor_loop_integration() {
-    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let log = Arc::new(Mutex::new(Vec::new()));
     let recorder = Recorder { log: log.clone() };
 
     let store = Store::new(
@@ -231,6 +232,80 @@ fn actor_loop_integration() {
     assert!(log.contains(&"Pong".to_string()));
     assert!(log.contains(&"Increment".to_string()));
     assert!(log.contains(&"SetLabel(\"done\")".to_string()));
+
+    assert_eq!(
+        store.state(),
+        &AppState {
+            count: CountSlice { value: 1 },
+            label: LabelSlice {
+                text: String::from("done"),
+            },
+        }
+    );
+}
+
+#[test]
+fn actor_loop_with_subscription_integration() {
+    let log = Arc::new(Mutex::new(Vec::new()));
+
+    let store = Store::new(
+        initial_state(),
+        ParallelRootReducer::new((CountReducer, LabelReducer)),
+        vec![],
+        10,
+    );
+
+    let (handle, actor_loop, mut listener) = init_actor_loop_with_subscription(store, 10);
+    let mut handle1 = handle.clone();
+    let dispatch_future_1 = async move {
+        handle1
+            .dispatch(Event::Ping)
+            .await
+            .expect("Dispatch should succeed");
+    };
+    let mut handle2 = handle.clone();
+    let dispatch_future_2 = async move {
+        handle2
+            .dispatch(Event::Increment)
+            .await
+            .expect("Dispatch should succeed");
+    };
+    let mut handle3 = handle.clone();
+    let dispatch_future_3 = async move {
+        handle3
+            .dispatch(Event::SetLabel(String::from("done")))
+            .await
+            .expect("Dispatch should succeed");
+    };
+    let log_clone = log.clone();
+    let listener_future = async move {
+        while let Some(state) = listener.next().await {
+            log_clone.lock().unwrap().push((*state).clone());
+        }
+    };
+    drop(handle); // Drop the original handle to avoid deadlock in the actor loop
+    let store = block_on(async {
+        let (_, _, _, _, loop_result) = join!(
+            listener_future,
+            dispatch_future_1,
+            dispatch_future_2,
+            dispatch_future_3,
+            actor_loop.run(),
+        );
+        loop_result.expect("Actor loop should complete successfully")
+    });
+
+    let log = log.lock().unwrap();
+
+    let expected_final_state = AppState {
+        count: CountSlice { value: 1 },
+        label: LabelSlice {
+            text: "done".to_string(),
+        },
+    };
+
+    assert_eq!(log.first(), Some(&initial_state()));
+    assert_eq!(log.last(), Some(&expected_final_state));
 
     assert_eq!(
         store.state(),


### PR DESCRIPTION
## What

Adds a state-change subscription to the async actor loop. External code observes state changes as an `impl Stream<Item = Arc<S>>`, obtained from a new `init_actor_loop_with_subscription`.

## How

- `src/watch.rs`: a hand-recoded `watch` channel on `futures`, no runtime dependency. Single versioned slot, coalesced so a slow receiver only sees the latest value. `poll_next` registers the waker before reading version/closed to avoid lost wakeups, and receivers are woken without holding any lock. Cloning a receiver adds an independent subscriber.
- `ActorLoop` publishes the settled state after each dispatch through a sealed `Publish` policy: `NoPublish` (default, no-op) keeps the non-subscribing path free of `S: Clone`; `WatchPublish` (opt-in) clones a snapshot only while a subscriber is alive.
- The public API hides the concrete channel: the constructor returns `impl Stream<Item = Arc<S>>`.
- The `async_dispatch` example gains a `SolarController` that reacts to state changes and dispatches commands back through its own handle, with cooperative shutdown via a `Termination` event.

## Tests

- `watch` unit tests: initial value, coalescing, wake-on-change, wake-on-sender-drop, drain-final-value-before-close, `has_receivers`.
- Integration test exercising the public subscription API end to end.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo doc` all green.

## Scope

Meets the acceptance criteria of #35, including multi-consumer subscription. Phase 3 (per-slice projection and `PartialEq` on-change dedup) is deferred to a follow-up, so this does not fully close the issue.

Refs #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
