### PR TITLE
test: de-flake watch multithreaded assertion

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -340,8 +340,14 @@ mod tests {
             sender.send(1);
         });
         block_on(async {
-            assert_eq!(receiver.next().await, Some(0));
-            assert_eq!(receiver.next().await, Some(1));
+            // The initial 0 may be coalesced away if the send wins the race;
+            // the level-triggered guarantee is that the last observed value is
+            // the latest one sent.
+            let mut last = None;
+            while let Some(v) = receiver.next().await {
+                last = Some(v);
+            }
+            assert_eq!(last, Some(1));
         });
         sender_thread.join().unwrap();
     }


### PR DESCRIPTION
## Problem

`watch::tests::multithreaded` is flaky on `main` (CI run 29742899771): it asserts `next()` yields the initial `0` then the sent `1`, but the sender runs on another thread, so when the `send` wins the race the initial value is coalesced away and the first `next()` already returns `1`.

## Fix

Drain the stream to the end and assert the last observed value is `1`, matching the level-triggered guarantee (the receiver eventually observes the latest value, regardless of whether it also saw intermediates). Verified stable over 40 local runs.

Follow-up to #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)