### PR TITLE
refactor!: reducer side events as Vec, refine max-depth error

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ flowchart TB
     ParRR[ParallelRootReducer only] -.requires.-> SS[StateSlices on State]
 ```
 
-Slice reducers compose into a root reducer via either [`SequentialRootReducer<T>`] (applies them in order, threading state through `set_slice`) or [`ParallelRootReducer<L, E, Indices>`] (applies them on Rayon workers, with compile-time disjointness verification). `Next<S, E>` is the dispatch-chain closure each middleware wraps, and `DispatchError` is returned when side-event recursion exceeds the configured depth.
+Slice reducers compose into a root reducer via either [`SequentialRootReducer<T>`] (applies them in order, updating each slice in place) or [`ParallelRootReducer<L, E, Indices>`] (applies them on Rayon workers, with compile-time disjointness verification). `Next<S, E>` is the dispatch-chain closure each middleware wraps, and `DispatchError` is returned when side-event recursion exceeds the configured depth.
 
 For exact signatures, trait bounds, and runnable examples, see the rustdoc — run `cargo doc --open` (it will be published on docs.rs once ruxe ships to crates.io).
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -11,7 +11,7 @@ Both update the state and produce a `ReducerOutput` containing optional side eve
 to re-dispatch.
 
 `HasSlice<T>` bridges the global state to a slice: the user implements it on their
-state struct to expose each slice (`slice_mut`).
+state struct to expose each slice (`slice`).
 
 ```mermaid
 classDiagram

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -227,9 +227,9 @@ impl Middleware<PlantState, Event> for BatteryControlMiddleware {
                     reactive_power: 0.0,
                 };
                 println!("Issuing command: {} to reduce battery output.", command);
-                let mut side_events = next(state, event).unwrap_or_default();
+                let mut side_events = next(state, event);
                 side_events.push(command);
-                Some(side_events)
+                side_events
             } else {
                 next(state, event)
             }
@@ -258,7 +258,7 @@ impl SliceReducer for SolarReducer {
             };
         }
 
-        None
+        vec![]
     }
 }
 
@@ -282,7 +282,11 @@ impl SliceReducer for BatteryReducer {
                     reactive_power: *reactive_power,
                 };
 
-                (state.state_of_charge < 20.0).then(|| vec![Event::BatteryStateOfChargeLow])
+                if state.state_of_charge < 20.0 {
+                    vec![Event::BatteryStateOfChargeLow]
+                } else {
+                    vec![]
+                }
             }
             Event::BatteryCommand {
                 active_power,
@@ -290,9 +294,9 @@ impl SliceReducer for BatteryReducer {
             } => {
                 state.active_power = *active_power;
                 state.reactive_power = *reactive_power;
-                None
+                vec![]
             }
-            _ => None,
+            _ => vec![],
         }
     }
 }
@@ -321,7 +325,7 @@ impl SliceReducer for PowerMeterReducer {
                 voltage: *voltage,
             };
         };
-        None
+        vec![]
     }
 }
 
@@ -337,7 +341,7 @@ impl SliceReducer for SystemReducer {
             state.termination_requested = true;
         }
 
-        None
+        vec![]
     }
 }
 

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -48,11 +48,11 @@ impl Reducer<State> for CounterReducer {
         match event {
             Event::Increment {} => {
                 state.value += 1;
-                None
+                vec![]
             }
             Event::Decrement {} => {
                 state.value -= 1;
-                None
+                vec![]
             }
         }
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -462,9 +462,9 @@ mod tests {
                 match event {
                     Append { value } => {
                         current_state.name.push(*value);
-                        None
+                        vec![]
                     }
-                    Recursive {} => Some(vec![Recursive {}]),
+                    Recursive {} => vec![Recursive {}],
                 }
             }
         }
@@ -527,7 +527,7 @@ mod tests {
             let result = block_on(actor_loop.run());
             match result {
                 Ok(_) => panic!("Actor loop should have failed due to max recursion depth"),
-                Err(err) => assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 10, max: 10 }),
+                Err(err) => assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 11, max: 10 }),
             }
         }
 

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -27,7 +27,7 @@ where
 }
 
 pub(crate) fn no_op<S, E>(_: &mut S, _: &E) -> ReducerOutput<E> {
-    None
+    vec![]
 }
 
 macro_rules! init_sliced_state {
@@ -146,7 +146,7 @@ pub(crate) mod shared_tests {
     ) {
         let mut state = make_state();
         let reducer_output = root_reducer.reduce(&mut state, &FirstValueUpdate { value: 2 });
-        assert_eq!(reducer_output, None);
+        assert!(reducer_output.is_empty());
     }
 
     pub(crate) fn aggregates_side_events_in_tuple_order<R: Reducer<ExampleState, Event = Event>>(
@@ -154,7 +154,7 @@ pub(crate) mod shared_tests {
     ) {
         let mut state = make_state();
         let reducer_output = root_reducer.reduce(&mut state, &SecondValueUpdate { value: 1.5 });
-        assert_eq!(reducer_output, Some(vec![SideEvent1 {}, SideEvent2 {}]))
+        assert_eq!(reducer_output, vec![SideEvent1 {}, SideEvent2 {}])
     }
 }
 
@@ -167,23 +167,23 @@ pub(crate) fn make_reducer_tuple() -> (
         ClosureSliceReducer::new(|slice: &mut FirstSlice, event: &Event| match event {
             FirstValueUpdate { value } => {
                 slice.value = *value;
-                None
+                vec![]
             }
             _ => no_op(slice, event),
         }),
         ClosureSliceReducer::new(|slice: &mut SecondSlice, event: &Event| match event {
             SecondValueUpdate { value } => {
                 slice.value = *value;
-                Some(vec![SideEvent1 {}])
+                vec![SideEvent1 {}]
             }
             _ => no_op(slice, event),
         }),
         ClosureSliceReducer::new(|slice: &mut ThirdSlice, event: &Event| match event {
             ThirdValueUpdate { value } => {
                 slice.value = value.clone();
-                None
+                vec![]
             }
-            SecondValueUpdate { value: _ } => Some(vec![SideEvent2 {}]),
+            SecondValueUpdate { value: _ } => vec![SideEvent2 {}],
             _ => no_op(slice, event),
         }),
     )

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -26,7 +26,7 @@
 ///
 /// Mutates state in place and returns any side events. Code running after
 /// `next` returns observes the updated state.
-pub type Next<S, E> = Box<dyn FnMut(&mut S, E) -> Option<Vec<E>>>;
+pub type Next<S, E> = Box<dyn FnMut(&mut S, E) -> Vec<E>>;
 
 /// A wrapper around the dispatch chain.
 ///

--- a/src/parallel_root_reducer.rs
+++ b/src/parallel_root_reducer.rs
@@ -30,9 +30,9 @@ use std::marker::PhantomData;
 /// # Runtime behavior
 ///
 /// Each slice reducer runs on a Rayon worker thread, taking a `&mut Slice`
-/// projection of the state. Each may update the slice and produce optional
-/// side events. The side events are concatenated **in tuple declaration
-/// order** (deterministic, independent of execution order).
+/// projection of the state. Each may update the slice and produce side
+/// events. The side events are concatenated **in tuple declaration order**
+/// (deterministic, independent of execution order).
 ///
 /// # Bounds
 ///
@@ -120,7 +120,7 @@ pub(crate) trait ApplyReducers<Reducers, S, E, Indices> {
 /// Implementation when recursion reaches the end of the tuple of slice reducers.
 impl<Reducers, S, E> ApplyReducers<Reducers, S, E, HNil> for HNil {
     fn apply(&mut self, _reducers: &Reducers, _event: &E) -> ReducerOutput<E> {
-        None
+        Vec::new()
     }
 }
 
@@ -141,16 +141,9 @@ where
             || self.tail.apply(reducers, event),
         );
 
-        let mut side_events = head_output.unwrap_or_default();
-        if let Some(rest_side_events) = rest_output {
-            side_events.extend(rest_side_events);
-        }
-
-        if side_events.is_empty() {
-            None
-        } else {
-            Some(side_events)
-        }
+        let mut side_events = head_output;
+        side_events.extend(rest_output);
+        side_events
     }
 }
 
@@ -239,7 +232,7 @@ mod tests {
                     match event {
                         FirstValueUpdate { value } => {
                             slice.value = *value;
-                            None
+                            vec![]
                         }
                         _ => no_op(slice, event),
                     }
@@ -249,7 +242,7 @@ mod tests {
                     match event {
                         SecondValueUpdate { value } => {
                             slice.value = *value;
-                            None
+                            vec![]
                         }
                         _ => no_op(slice, event),
                     }
@@ -259,9 +252,9 @@ mod tests {
                     match event {
                         ThirdValueUpdate { value } => {
                             slice.value = value.clone();
-                            None
+                            vec![]
                         }
-                        SecondValueUpdate { value: _ } => None,
+                        SecondValueUpdate { value: _ } => vec![],
                         _ => no_op(slice, event),
                     }
                 }),

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -3,9 +3,8 @@
 //! [`Reducer`] operates on the full state. [`SliceReducer`] operates on an
 //! isolated slice and composes with peers via tuple syntax (up to arity 12).
 
-/// The output of a reducer.
-/// Optional events to re-dispatch through the store.
-pub type ReducerOutput<E> = Option<Vec<E>>;
+/// The output of a reducer: events to re-dispatch through the store, empty for none.
+pub type ReducerOutput<E> = Vec<E>;
 
 /// A `Reducer` updates `state` according to `event`.
 ///

--- a/src/sequential_root_reducer.rs
+++ b/src/sequential_root_reducer.rs
@@ -63,12 +63,10 @@ macro_rules! impl_sequential_reducer_tuple {
 
                 $(
                     let new_side_events = self.reducers.$idx.reduce(state.slice(), event);
-                    if let Some(events) = new_side_events {
-                        side_events.extend(events);
-                    }
+                    side_events.extend(new_side_events);
                 )+
 
-                if side_events.is_empty() { None } else { Some(side_events) }
+                side_events
             }
         }
     };
@@ -135,7 +133,7 @@ mod tests {
             ClosureSliceReducer::new(|slice: &mut FirstSlice, event: &Event| match event {
                 FirstValueOrderingTest {} => {
                     slice.value = 1;
-                    None
+                    vec![]
                 }
                 _ => no_op(slice, event),
             })
@@ -145,7 +143,7 @@ mod tests {
             ClosureSliceReducer::new(|slice: &mut FirstSlice, event: &Event| match event {
                 FirstValueOrderingTest {} => {
                     slice.value = 0;
-                    None
+                    vec![]
                 }
                 _ => no_op(slice, event),
             })

--- a/src/sequential_root_reducer.rs
+++ b/src/sequential_root_reducer.rs
@@ -1,6 +1,6 @@
 //! Sequential root reducer: applies a tuple of [`SliceReducer`]s in
-//! declaration order, threading the state through chained `set_slice`
-//! calls. See [`SequentialRootReducer`] for usage.
+//! declaration order, updating each slice in place. See
+//! [`SequentialRootReducer`] for usage.
 
 use crate::{HasSlice, Reducer, ReducerOutput, SliceReducer};
 
@@ -9,10 +9,9 @@ use crate::{HasSlice, Reducer, ReducerOutput, SliceReducer};
 ///
 /// # Behavior
 ///
-/// On each [`Reducer::reduce`] call, the state is cloned once, then each
-/// slice reducer is invoked in order. Each reducer's output replaces the
-/// corresponding slice (via [`HasSlice::set_slice`]) before the next reducer
-/// runs. Side events from all reducers are concatenated in tuple order.
+/// On each [`Reducer::reduce`] call, each slice reducer runs in order,
+/// updating its slice in place via [`HasSlice::slice`]. Side events from all
+/// reducers are concatenated in tuple order.
 ///
 /// # When to use
 ///

--- a/src/store.rs
+++ b/src/store.rs
@@ -13,7 +13,7 @@ use std::fmt::Display;
 pub enum DispatchError {
     /// Side-event recursion exceeded `max_depth`.
     MaxDepthExceeded {
-        /// Depth at which the offending event was produced (0 = original dispatch).
+        /// Depth the refused side events would have occupied; always `max_depth + 1`.
         depth: usize,
         /// The configured `max_depth` limit passed to [`Store::new`].
         max: usize,
@@ -25,7 +25,7 @@ impl Display for DispatchError {
         match self {
             DispatchError::MaxDepthExceeded { depth, max } => write!(
                 f,
-                "Side-event recursion limit reached: event at depth {} emitted side events (max_depth = {})",
+                "Side-event recursion would reach depth {}, exceeding max_depth ({})",
                 depth, max
             ),
         }
@@ -71,9 +71,8 @@ impl<S, E> Store<S, E> {
         S: 'static,
         E: 'static,
     {
-        let base = Box::new(move |state: &mut S, event: E| -> Option<Vec<E>> {
-            reducer.reduce(state, &event)
-        });
+        let base =
+            Box::new(move |state: &mut S, event: E| -> Vec<E> { reducer.reduce(state, &event) });
         Store {
             state,
             chain: middlewares
@@ -105,23 +104,24 @@ impl<S, E> Store<S, E> {
 
     fn queue_side_events(
         &mut self,
-        events: Option<Vec<E>>,
+        events: Vec<E>,
         current_depth: usize,
     ) -> Result<(), DispatchError> {
-        if let Some(events) = events {
-            if current_depth >= self.max_depth {
-                return Err(DispatchError::MaxDepthExceeded {
-                    depth: current_depth,
-                    max: self.max_depth,
-                });
-            }
+        if events.is_empty() {
+            return Ok(());
+        }
+        if current_depth >= self.max_depth {
+            return Err(DispatchError::MaxDepthExceeded {
+                depth: current_depth + 1,
+                max: self.max_depth,
+            });
+        }
 
-            for event in events {
-                self.queue.push_back(PendingEvent {
-                    event,
-                    depth: current_depth + 1,
-                })
-            }
+        for event in events {
+            self.queue.push_back(PendingEvent {
+                event,
+                depth: current_depth + 1,
+            })
         }
         Ok(())
     }
@@ -163,16 +163,16 @@ mod tests {
                 match event {
                     FirstValueUpdate { value } => {
                         state.first_value = *value;
-                        None
+                        vec![]
                     }
                     SecondValueUpdate { value } => {
                         state.second_value = *value;
-                        None
+                        vec![]
                     }
-                    EmitSide {} => Some(vec![SecondValueUpdate { value: 2 }, IgnoredUpdate {}]),
-                    EmitNestedSide {} => Some(vec![EmitSide {}, FirstValueUpdate { value: 2.0 }]),
-                    EmitSelfRecursive {} => Some(vec![EmitSelfRecursive {}]),
-                    _ => None,
+                    EmitSide {} => vec![SecondValueUpdate { value: 2 }, IgnoredUpdate {}],
+                    EmitNestedSide {} => vec![EmitSide {}, FirstValueUpdate { value: 2.0 }],
+                    EmitSelfRecursive {} => vec![EmitSelfRecursive {}],
+                    _ => vec![],
                 }
             }
         }
@@ -298,7 +298,7 @@ mod tests {
             let err = store
                 .dispatch(EmitSelfRecursive {})
                 .expect_err("Should return an error");
-            assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 10, max: 10 });
+            assert_eq!(err, DispatchError::MaxDepthExceeded { depth: 11, max: 10 });
         }
     }
 
@@ -368,7 +368,7 @@ mod tests {
 
             impl Middleware<SimpleState, Event> for ShortCircuitMiddleware {
                 fn wrap(self: Box<Self>, _: Next<SimpleState, Event>) -> Next<SimpleState, Event> {
-                    Box::new(|_, _| None)
+                    Box::new(|_, _| vec![])
                 }
             }
 
@@ -397,6 +397,10 @@ mod tests {
                     push_msg("Pre-Middleware2"),
                     push_msg("Post-Middleware2"),
                 )),
+                Box::new(ProbeMiddleware::<SimpleState, Event>::new(
+                    push_msg("Pre-Middleware3"),
+                    push_msg("Post-Middleware3"),
+                )),
             ];
 
             let mut store = make_store(middlewares);
@@ -410,6 +414,8 @@ mod tests {
                 vec![
                     "Pre-Middleware1",
                     "Pre-Middleware2",
+                    "Pre-Middleware3",
+                    "Post-Middleware3",
                     "Post-Middleware2",
                     "Post-Middleware1",
                 ]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -62,10 +62,10 @@ impl SliceReducer for CountReducer {
         match event {
             Event::Increment => {
                 slice.value += 1;
-                None
+                vec![]
             }
-            Event::Ping => Some(vec![Event::Pong]),
-            _ => None,
+            Event::Ping => vec![Event::Pong],
+            _ => vec![],
         }
     }
 }
@@ -79,7 +79,7 @@ impl SliceReducer for LabelReducer {
             slice.text = text.clone();
         }
 
-        None
+        vec![]
     }
 }
 

--- a/tests/ui/duplicate_slice.rs
+++ b/tests/ui/duplicate_slice.rs
@@ -68,9 +68,9 @@ fn main() {
             match event {
                 MyEvent::UpdateFirst(v) => {
                     slice.value = v.value;
-                    None
+                    vec![]
                 }
-                _ => None,
+                _ => vec![],
             }
         }
     }
@@ -85,9 +85,9 @@ fn main() {
             match event {
                 MyEvent::UpdateSecond(v) => {
                     slice.value = v.value;
-                    None
+                    vec![]
                 }
-                _ => None,
+                _ => vec![],
             }
         }
     }

--- a/tests/ui/missing_reducer.rs
+++ b/tests/ui/missing_reducer.rs
@@ -70,9 +70,9 @@ fn main() {
             match event {
                 MyEvent::UpdateFirst(v) => {
                     slice.value = v.value;
-                    None
+                    vec![]
                 }
-                _ => None,
+                _ => vec![],
             }
         }
     }


### PR DESCRIPTION
`ReducerOutput.side_events` and `Next` go from `Option<Vec<E>>` to `Vec<E>` (empty = none). `None` and `Some(vec![])` meant the same thing but behaved differently at the depth guard: an empty `Some` at `max_depth` raised `MaxDepthExceeded` without emitting anything.

`MaxDepthExceeded` reported the emitting event's depth, which is always `max_depth` (nothing is queued deeper), so `depth` and `max` were always equal. Now it reports `max_depth + 1`, the depth the refused events would have had.

Onion-order test goes from 2 to 3 middleware levels.

Breaking:

```rust
None            -> vec![]
Some(vec![..])  -> vec![..]
```